### PR TITLE
refactor: mejora consulta en UsuarioRepository

### DIFF
--- a/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/Usuarios/UsuarioRepository.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/Usuarios/UsuarioRepository.cs
@@ -2,7 +2,6 @@ using BackendCConecta.Dominio.Entidades.Usuarios;
 using BackendCConecta.Dominio.Repositorios;
 using BackendCConecta.Infraestructura.Persistencia;
 using Microsoft.EntityFrameworkCore;
-using System.Threading;
 
 namespace BackendCConecta.Infraestructura.Repositorios.Usuarios;
 
@@ -18,6 +17,7 @@ public class UsuarioRepository : RepositorioGenerico<Usuario>, IUsuarioRepositor
     /// <inheritdoc />
     public async Task<Usuario?> ObtenerPorCorreoAsync(string correo, CancellationToken cancellationToken = default)
     {
-        return await _dbSet.FirstOrDefaultAsync(u => u.CorreoElectronico == correo, cancellationToken);
+        return await _dbSet.AsNoTracking()
+            .FirstOrDefaultAsync(u => u.CorreoElectronico == correo, cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
- evita el seguimiento de entidades en `ObtenerPorCorreoAsync`
- limpia directivas de `using` sin utilizar

## Testing
- `dotnet build BackendCConecta.sln` *(failed: bash: command not found: dotnet)*
- `apt-get update` *(failed: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6895230c6818832e8475b36563f82868