### PR TITLE
feat: handle login failures with result

### DIFF
--- a/BackendCConecta/BackendCConecta/Api/Controllers/AuthController.cs
+++ b/BackendCConecta/BackendCConecta/Api/Controllers/AuthController.cs
@@ -19,7 +19,11 @@ namespace BackendCConecta.Api.Controllers
         public async Task<IActionResult> Login([FromBody] LoginRequestDto request)
         {
             var result = await _authService.LoginAsync(request);
-            return Ok(result);
+            if (!result.Success)
+            {
+                return Unauthorized(new { message = result.Error });
+            }
+            return Ok(result.Data);
         }
 
         [HttpPost("refresh")]

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Auth/Comandos/LoginCommand.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Auth/Comandos/LoginCommand.cs
@@ -3,7 +3,7 @@ using BackendCConecta.Aplicacion.Modulos.Auth.DTOs;
 
 namespace BackendCConecta.Aplicacion.Modulos.Auth.Comandos
 {
-    public class LoginCommand : IRequest<LoginResponseDto?>
+    public class LoginCommand : IRequest<Result<LoginResponseDto>>
     {
         public string CorreoElectronico { get; set; } = default!;
         public string Password { get; set; } = default!;

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Auth/DTOs/Result.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Auth/DTOs/Result.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace BackendCConecta.Aplicacion.Modulos.Auth.DTOs
+{
+    public class Result<T>
+    {
+        public bool Success { get; init; }
+        public T? Data { get; init; }
+        public string? Error { get; init; }
+
+        public static Result<T> SuccessResult(T data) => new Result<T> { Success = true, Data = data };
+        public static Result<T> Failure(string error) => new Result<T> { Success = false, Error = error };
+    }
+}

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Auth/Handlers/LoginCommandHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Auth/Handlers/LoginCommandHandler.cs
@@ -9,7 +9,7 @@ namespace BackendCConecta.Aplicacion.Modulos.Auth.Handlers
 
 {
 
-    public class LoginCommandHandler : IRequestHandler<LoginCommand, LoginResponseDto?>
+    public class LoginCommandHandler : IRequestHandler<LoginCommand, Result<LoginResponseDto>>
     {
         private readonly IAuthService _authService;
 
@@ -18,7 +18,7 @@ namespace BackendCConecta.Aplicacion.Modulos.Auth.Handlers
             _authService = authService;
         }
 
-        public async Task<LoginResponseDto?> Handle(LoginCommand request, CancellationToken cancellationToken)
+        public async Task<Result<LoginResponseDto>> Handle(LoginCommand request, CancellationToken cancellationToken)
         {
             var loginRequest = new LoginRequestDto
             {

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Auth/Interfaces/IAuthService.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Auth/Interfaces/IAuthService.cs
@@ -9,7 +9,7 @@ namespace BackendCConecta.Aplicacion.Modulos.Auth.Interfaces
     /// </summary>
     public interface IAuthService
     {
-        Task<LoginResponseDto?> LoginAsync(LoginRequestDto request, CancellationToken cancellationToken = default);
+        Task<Result<LoginResponseDto>> LoginAsync(LoginRequestDto request, CancellationToken cancellationToken = default);
         Task<LoginResponseDto?> RefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
## Summary
- return a Result wrapper from `AuthService.LoginAsync` and log failed login attempts
- send 401 responses with descriptive messages for bad credentials or inactive users
- add generic `Result<T>` type

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689532ce9a00832ea241c99b82c47bde