### PR TITLE
Improve password hashing format and security

### DIFF
--- a/BackendCConecta/BackendCConecta/Aplicacion/InterfacesGenerales/IPasswordHasher.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/InterfacesGenerales/IPasswordHasher.cs
@@ -1,5 +1,10 @@
 namespace BackendCConecta.Aplicacion.InterfacesGenerales
 {
+    /// <summary>
+    /// Define operaciones para generar y verificar hashes de contraseñas.
+    /// Los hashes se almacenan como <c>iteraciones.prf.salt.hash</c> en Base64.
+    /// El formato legacy <c>salt.hash</c> continúa siendo soportado.
+    /// </summary>
     public interface IPasswordHasher
     {
         string HashearPassword(string password);

--- a/BackendCConecta/BackendCConecta/Infraestructura/Seguridad/PasswordHasher.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Seguridad/PasswordHasher.cs
@@ -1,39 +1,75 @@
-﻿using BackendCConecta.Aplicacion.InterfacesGenerales;
-using System.Security.Cryptography;
+using BackendCConecta.Aplicacion.InterfacesGenerales;
 using Microsoft.AspNetCore.Cryptography.KeyDerivation;
+using System;
+using System.Security.Cryptography;
 
 namespace BackendCConecta.Infraestructura.Seguridad
 {
+    /// <summary>
+    /// Implementación de <see cref="IPasswordHasher"/> basada en PBKDF2.
+    /// El formato de almacenamiento es "iteraciones.prf.salt.hash".
+    /// Para compatibilidad, también se aceptan valores antiguos con el
+    /// esquema "salt.hash" que asumen HMACSHA256 y 10&nbsp;000 iteraciones.
+    /// </summary>
     public class PasswordHasher : IPasswordHasher
     {
+        private const KeyDerivationPrf Prf = KeyDerivationPrf.HMACSHA256;
+        private const int IterationCount = 100000; // Recomendado >=100000
+        private const int LegacyIterationCount = 10000;
+        private const int SaltSize = 128 / 8;
+        private const int NumBytesRequested = 256 / 8;
+
         public string HashearPassword(string password)
         {
-            byte[] salt = RandomNumberGenerator.GetBytes(128 / 8);
-
-            string hash = Convert.ToBase64String(KeyDerivation.Pbkdf2(
+            byte[] salt = RandomNumberGenerator.GetBytes(SaltSize);
+            byte[] hash = KeyDerivation.Pbkdf2(
                 password: password,
                 salt: salt,
-                prf: KeyDerivationPrf.HMACSHA256,
-                iterationCount: 10000,
-                numBytesRequested: 256 / 8));
+                prf: Prf,
+                iterationCount: IterationCount,
+                numBytesRequested: NumBytesRequested);
 
-            return $"{Convert.ToBase64String(salt)}.{hash}";
+            return $"{IterationCount}.{Prf}.{Convert.ToBase64String(salt)}.{Convert.ToBase64String(hash)}";
         }
 
         public bool VerificarPassword(string passwordPlano, string hash)
         {
             var partes = hash.Split('.');
-            if (partes.Length != 2) return false;
+            KeyDerivationPrf prf;
+            int iterations;
+            byte[] salt;
+            byte[] hashAlmacenado;
 
-            var salt = Convert.FromBase64String(partes[0]);
-            var hashComparar = Convert.ToBase64String(KeyDerivation.Pbkdf2(
+            if (partes.Length == 2)
+            {
+                // Formato antiguo: salt.hash
+                prf = Prf;
+                iterations = LegacyIterationCount;
+                salt = Convert.FromBase64String(partes[0]);
+                hashAlmacenado = Convert.FromBase64String(partes[1]);
+            }
+            else if (partes.Length == 4)
+            {
+                // Formato nuevo: iteraciones.prf.salt.hash
+                if (!int.TryParse(partes[0], out iterations)) return false;
+                if (!Enum.TryParse(partes[1], out prf)) return false;
+                salt = Convert.FromBase64String(partes[2]);
+                hashAlmacenado = Convert.FromBase64String(partes[3]);
+            }
+            else
+            {
+                return false;
+            }
+
+            byte[] hashComparar = KeyDerivation.Pbkdf2(
                 password: passwordPlano,
                 salt: salt,
-                prf: KeyDerivationPrf.HMACSHA256,
-                iterationCount: 10000,
-                numBytesRequested: 256 / 8));
+                prf: prf,
+                iterationCount: iterations,
+                numBytesRequested: NumBytesRequested);
 
-            return hashComparar == partes[1];
+            return CryptographicOperations.FixedTimeEquals(hashAlmacenado, hashComparar);
         }
     }
 }
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # BackendCConecta
 Backend para la plataforma Cusco Conecta
+
+## Esquema de hashing de contraseñas
+
+Las contraseñas se almacenan utilizando PBKDF2 con un formato que incluye los
+parámetros del algoritmo para permitir futuras migraciones. El esquema actual es:
+
+```
+iteraciones.prf.salt.hash
+```
+
+- `iteraciones`: número de iteraciones utilizadas (por defecto 100 000).
+- `prf`: función de derivación, actualmente `HMACSHA256`.
+- `salt`: valor aleatorio en Base64.
+- `hash`: resultado PBKDF2 en Base64.
+
+Los valores antiguos con el formato anterior `salt.hash` siguen siendo válidos y
+asumen 10 000 iteraciones y `HMACSHA256` como función de derivación.


### PR DESCRIPTION
## Summary
- increase PBKDF2 iterations and embed parameters in hash string
- compare hashes in constant time and support legacy salt.hash values
- document new password hash format

## Testing
- `dotnet test BackendCConecta/BackendCConecta.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_689536963b48832e93c0c7365be61668