### PR TITLE
refactor: move DatosPersona to Personas domain

### DIFF
--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/DatosPersona/Handlers/CrearDatosPersonaHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/DatosPersona/Handlers/CrearDatosPersonaHandler.cs
@@ -1,7 +1,7 @@
 ﻿using MediatR;
 using BackendCConecta.Aplicacion.Modulos.DatosPersona.Comandos;
 using BackendCConecta.Aplicacion.Modulos.DatosPersona.Interfaces;
-using BackendCConecta.Dominio.Entidades.Usuarios;
+using BackendCConecta.Dominio.Entidades.Personas;
 
 namespace BackendCConecta.Aplicacion.Modulos.DatosPersona.Handlers;
 

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/DatosPersona/Interfaces/IDatosPersonaRepository.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/DatosPersona/Interfaces/IDatosPersonaRepository.cs
@@ -1,4 +1,4 @@
-﻿using BackendCConecta.Dominio.Entidades.Empresas;
+using BackendCConecta.Dominio.Entidades.Personas;
 
 namespace BackendCConecta.Aplicacion.Modulos.DatosPersona.Interfaces;
 
@@ -9,3 +9,4 @@ public interface IDatosPersonaRepository
     Task EliminarAsync(int idDatosUsuario);
     Task<DatosPersona?> ObtenerPorIdAsync(int idDatosUsuario);
 }
+

--- a/BackendCConecta/BackendCConecta/Dominio/Entidades/Personas/DatosPersona.cs
+++ b/BackendCConecta/BackendCConecta/Dominio/Entidades/Personas/DatosPersona.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using BackendCConecta.Dominio.Entidades.UsuariosDatos;
 
-namespace BackendCConecta.Dominio.Entidades.Empresas;
+namespace BackendCConecta.Dominio.Entidades.Personas;
 
 public partial class DatosPersona
 {

--- a/BackendCConecta/BackendCConecta/Dominio/Entidades/UsuariosDatos/DatosUsuario.cs
+++ b/BackendCConecta/BackendCConecta/Dominio/Entidades/UsuariosDatos/DatosUsuario.cs
@@ -9,6 +9,7 @@ using BackendCConecta.Dominio.Entidades.Roles;
 using BackendCConecta.Dominio.Entidades.Paquetes;
 using BackendCConecta.Dominio.Entidades.Usuarios;
 using BackendCConecta.Dominio.Entidades.Empresas;
+using BackendCConecta.Dominio.Entidades.Personas;
 
 namespace BackendCConecta.Dominio.Entidades.UsuariosDatos;
 

--- a/BackendCConecta/BackendCConecta/Infraestructura/Persistencia/AppDbContext.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Persistencia/AppDbContext.cs
@@ -21,6 +21,7 @@ using BackendCConecta.Dominio.Entidades.Contactos;
 
 // 🏢 Empresas y Personas
 using BackendCConecta.Dominio.Entidades.Empresas;
+using BackendCConecta.Dominio.Entidades.Personas;
 
 // 🎉 Eventos
 using BackendCConecta.Dominio.Entidades.Eventos;

--- a/BackendCConecta/BackendCConecta/Infraestructura/Persistencia/Configuration/Usuarios/DatosPersonaConfiguration.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Persistencia/Configuration/Usuarios/DatosPersonaConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using BackendCConecta.Dominio.Entidades.Usuarios;
+using BackendCConecta.Dominio.Entidades.Personas;
 
 namespace BackendCConecta.Infraestructura.Persistencia.Configuraciones.Usuarios;
 

--- a/BackendCConecta/BackendCConecta/Infraestructura/Persistencia/Configuration/Usuarios/DatosUsuarioConfiguration.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Persistencia/Configuration/Usuarios/DatosUsuarioConfiguration.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore;
-using BackendCConecta.Dominio.Entidades.UsuariosAll;
+using BackendCConecta.Dominio.Entidades.UsuariosDatos;
+using BackendCConecta.Dominio.Entidades.Personas;
+using BackendCConecta.Dominio.Entidades.Empresas;
 
 namespace BackendCConecta.Infraestructura.Persistencia.Configuraciones.Usuarios
 {

--- a/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/DatosPersona/DatosPersonaRepository.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/DatosPersona/DatosPersonaRepository.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using BackendCConecta.Aplicacion.Modulos.DatosPersona.Interfaces;
 using BackendCConecta.Infraestructura.Persistencia;
+using BackendCConecta.Dominio.Entidades.Personas;
 
 namespace BackendCConecta.Infraestructura.Repositorios.DatosPersona;
 
@@ -15,29 +16,29 @@ public class DatosPersonaRepository : IDatosPersonaRepository
 
     public async Task CrearAsync(DatosPersona entidad)
     {
-        _context.DatosPersona.Add(entidad);
+        _context.DatosPersonas.Add(entidad);
         await _context.SaveChangesAsync();
     }
 
     public async Task ActualizarAsync(DatosPersona entidad)
     {
-        _context.DatosPersona.Update(entidad);
+        _context.DatosPersonas.Update(entidad);
         await _context.SaveChangesAsync();
     }
 
     public async Task EliminarAsync(int idDatosUsuario)
     {
-        var entidad = await _context.DatosPersona.FindAsync(idDatosUsuario);
+        var entidad = await _context.DatosPersonas.FindAsync(idDatosUsuario);
         if (entidad != null)
         {
-            _context.DatosPersona.Remove(entidad);
+            _context.DatosPersonas.Remove(entidad);
             await _context.SaveChangesAsync();
         }
     }
 
     public async Task<DatosPersona?> ObtenerPorIdAsync(int idDatosUsuario)
     {
-        return await _context.DatosPersona
+        return await _context.DatosPersonas
                              .AsNoTracking()
                              .FirstOrDefaultAsync(x => x.IdDatosUsuario == idDatosUsuario);
     }

--- a/BackendCConecta/BackendCConecta/Infraestructura/Servicios/DatosPersona/DatosPersonaQueryService.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Servicios/DatosPersona/DatosPersonaQueryService.cs
@@ -16,7 +16,7 @@ public class DatosPersonaQueryService : IDatosPersonaQueryService
 
     public async Task<IEnumerable<DatosPersonaDto>> ListarAsync()
     {
-        return await _context.DatosPersona
+        return await _context.DatosPersonas
             .AsNoTracking()
             .Select(p => new DatosPersonaDto
             {
@@ -31,7 +31,7 @@ public class DatosPersonaQueryService : IDatosPersonaQueryService
 
     public async Task<DatosPersonaDto?> ObtenerPorIdAsync(int idDatosUsuario)
     {
-        return await _context.DatosPersona
+        return await _context.DatosPersonas
             .AsNoTracking()
             .Where(p => p.IdDatosUsuario == idDatosUsuario)
             .Select(p => new DatosPersonaDto


### PR DESCRIPTION
## Summary
- move `DatosPersona` entity to new `Personas` domain folder and namespace
- update dependent domain, infrastructure, and application classes to use the new `Personas` namespace and DbSet name
- adjust repository and service code to operate on `DatosPersonas`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689536e94900832e917414f32c8c2526