### PR TITLE
Add AutoMapper profile and refactor Acuerdos handlers

### DIFF
--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Comandos/ActualizarAcuerdoComercialCommand.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Comandos/ActualizarAcuerdoComercialCommand.cs
@@ -1,6 +1,8 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Comandos
+using MediatR;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.DTOs;
+
+namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Comandos;
+
+public class ActualizarAcuerdoComercialCommand : ActualizarAcuerdoDto, IRequest<bool>
 {
-    public class ActualizarAcuerdoComercialCommand
-    {
-    }
 }

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Comandos/CrearAcuerdoComercialCommand.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Comandos/CrearAcuerdoComercialCommand.cs
@@ -1,6 +1,8 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Comandos
+using MediatR;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.DTOs;
+
+namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Comandos;
+
+public class CrearAcuerdoComercialCommand : CrearAcuerdoDto, IRequest<int>
 {
-    public class CrearAcuerdoComercialCommand
-    {
-    }
 }

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Comandos/EliminarAcuerdoComercialCommand.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Comandos/EliminarAcuerdoComercialCommand.cs
@@ -1,6 +1,8 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Comandos
+using MediatR;
+
+namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Comandos;
+
+public class EliminarAcuerdoComercialCommand : IRequest<bool>
 {
-    public class EliminarAcuerdoComercialCommand
-    {
-    }
+    public int Id { get; set; }
 }

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Consultas/ListarAcuerdosQuery.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Consultas/ListarAcuerdosQuery.cs
@@ -1,6 +1,9 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Consultas
+using MediatR;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.DTOs;
+using System.Collections.Generic;
+
+namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Consultas;
+
+public class ListarAcuerdosQuery : IRequest<List<AcuerdoDto>>
 {
-    public class ListarAcuerdosQuery
-    {
-    }
 }

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Consultas/ObtenerAcuerdoPorIdQuery.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Consultas/ObtenerAcuerdoPorIdQuery.cs
@@ -1,6 +1,9 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Consultas
+using MediatR;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.DTOs;
+
+namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Consultas;
+
+public class ObtenerAcuerdoPorIdQuery : IRequest<AcuerdoDto?>
 {
-    public class ObtenerAcuerdoPorIdQuery
-    {
-    }
+    public int Id { get; set; }
 }

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Consultas/ObtenerAcuerdosPorUsuarioQuery.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Consultas/ObtenerAcuerdosPorUsuarioQuery.cs
@@ -1,6 +1,10 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Consultas
+using MediatR;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.DTOs;
+using System.Collections.Generic;
+
+namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Consultas;
+
+public class ObtenerAcuerdosPorUsuarioQuery : IRequest<List<AcuerdoDto>>
 {
-    public class ObtenerAcuerdosPorUsuarioQuery
-    {
-    }
+    public int IdDatosUsuario { get; set; }
 }

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Handlers/ActualizarAcuerdoHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Handlers/ActualizarAcuerdoHandler.cs
@@ -1,6 +1,25 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Handlers
+using AutoMapper;
+using MediatR;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.Interfaces;
+using BackendCConecta.Dominio.Entidades.Acuerdos;
+
+namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Handlers;
+
+public class ActualizarAcuerdoHandler : IRequestHandler<ActualizarAcuerdoComercialCommand, bool>
 {
-    public class ActualizarAcuerdoHandler
+    private readonly IAcuerdoCommandService _service;
+    private readonly IMapper _mapper;
+
+    public ActualizarAcuerdoHandler(IAcuerdoCommandService service, IMapper mapper)
     {
+        _service = service;
+        _mapper = mapper;
+    }
+
+    public async Task<bool> Handle(ActualizarAcuerdoComercialCommand request, CancellationToken cancellationToken)
+    {
+        var entidad = _mapper.Map<AcuerdosComercial>(request);
+        return await _service.ActualizarAsync(entidad);
     }
 }

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Handlers/CrearAcuerdoHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Handlers/CrearAcuerdoHandler.cs
@@ -1,6 +1,25 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Handlers
+using AutoMapper;
+using MediatR;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.Interfaces;
+using BackendCConecta.Dominio.Entidades.Acuerdos;
+
+namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Handlers;
+
+public class CrearAcuerdoHandler : IRequestHandler<CrearAcuerdoComercialCommand, int>
 {
-    public class CrearAcuerdoHandler
+    private readonly IAcuerdoCommandService _service;
+    private readonly IMapper _mapper;
+
+    public CrearAcuerdoHandler(IAcuerdoCommandService service, IMapper mapper)
     {
+        _service = service;
+        _mapper = mapper;
+    }
+
+    public async Task<int> Handle(CrearAcuerdoComercialCommand request, CancellationToken cancellationToken)
+    {
+        var entidad = _mapper.Map<AcuerdosComercial>(request);
+        return await _service.CrearAsync(entidad);
     }
 }

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Handlers/EliminarAcuerdoHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Handlers/EliminarAcuerdoHandler.cs
@@ -1,6 +1,20 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Handlers
+using MediatR;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.Interfaces;
+
+namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Handlers;
+
+public class EliminarAcuerdoHandler : IRequestHandler<EliminarAcuerdoComercialCommand, bool>
 {
-    public class EliminarAcuerdoHandler
+    private readonly IAcuerdoCommandService _service;
+
+    public EliminarAcuerdoHandler(IAcuerdoCommandService service)
     {
+        _service = service;
+    }
+
+    public Task<bool> Handle(EliminarAcuerdoComercialCommand request, CancellationToken cancellationToken)
+    {
+        return _service.EliminarAsync(request.Id);
     }
 }

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Handlers/ListarAcuerdosHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Handlers/ListarAcuerdosHandler.cs
@@ -1,6 +1,25 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Handlers
+using AutoMapper;
+using MediatR;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.Consultas;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.DTOs;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.Interfaces;
+
+namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Handlers;
+
+public class ListarAcuerdosHandler : IRequestHandler<ListarAcuerdosQuery, List<AcuerdoDto>>
 {
-    public class ListarAcuerdosHandler
+    private readonly IAcuerdoQueryService _service;
+    private readonly IMapper _mapper;
+
+    public ListarAcuerdosHandler(IAcuerdoQueryService service, IMapper mapper)
     {
+        _service = service;
+        _mapper = mapper;
+    }
+
+    public async Task<List<AcuerdoDto>> Handle(ListarAcuerdosQuery request, CancellationToken cancellationToken)
+    {
+        var acuerdos = await _service.ListarAsync();
+        return _mapper.Map<List<AcuerdoDto>>(acuerdos);
     }
 }

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Handlers/ObtenerAcuerdoPorIdHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Handlers/ObtenerAcuerdoPorIdHandler.cs
@@ -1,6 +1,25 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Handlers
+using AutoMapper;
+using MediatR;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.Consultas;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.DTOs;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.Interfaces;
+
+namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Handlers;
+
+public class ObtenerAcuerdoPorIdHandler : IRequestHandler<ObtenerAcuerdoPorIdQuery, AcuerdoDto?>
 {
-    public class ObtenerAcuerdoPorIdHandler
+    private readonly IAcuerdoQueryService _service;
+    private readonly IMapper _mapper;
+
+    public ObtenerAcuerdoPorIdHandler(IAcuerdoQueryService service, IMapper mapper)
     {
+        _service = service;
+        _mapper = mapper;
+    }
+
+    public async Task<AcuerdoDto?> Handle(ObtenerAcuerdoPorIdQuery request, CancellationToken cancellationToken)
+    {
+        var acuerdo = await _service.ObtenerPorIdAsync(request.Id);
+        return acuerdo is null ? null : _mapper.Map<AcuerdoDto>(acuerdo);
     }
 }

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Handlers/ObtenerAcuerdosPorUsuarioHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Handlers/ObtenerAcuerdosPorUsuarioHandler.cs
@@ -1,6 +1,25 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Handlers
+using AutoMapper;
+using MediatR;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.Consultas;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.DTOs;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.Interfaces;
+
+namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Handlers;
+
+public class ObtenerAcuerdosPorUsuarioHandler : IRequestHandler<ObtenerAcuerdosPorUsuarioQuery, List<AcuerdoDto>>
 {
-    public class ObtenerAcuerdosPorUsuarioHandler
+    private readonly IAcuerdoQueryService _service;
+    private readonly IMapper _mapper;
+
+    public ObtenerAcuerdosPorUsuarioHandler(IAcuerdoQueryService service, IMapper mapper)
     {
+        _service = service;
+        _mapper = mapper;
+    }
+
+    public async Task<List<AcuerdoDto>> Handle(ObtenerAcuerdosPorUsuarioQuery request, CancellationToken cancellationToken)
+    {
+        var acuerdos = await _service.ObtenerPorUsuarioAsync(request.IdDatosUsuario);
+        return _mapper.Map<List<AcuerdoDto>>(acuerdos);
     }
 }

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Interfaces/IAcuerdoCommandService.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Interfaces/IAcuerdoCommandService.cs
@@ -1,6 +1,11 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Interfaces
+using BackendCConecta.Dominio.Entidades.Acuerdos;
+using System.Threading.Tasks;
+
+namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Interfaces;
+
+public interface IAcuerdoCommandService
 {
-    public class IAcuerdoCommandService
-    {
-    }
+    Task<int> CrearAsync(AcuerdosComercial entidad);
+    Task<bool> ActualizarAsync(AcuerdosComercial entidad);
+    Task<bool> EliminarAsync(int id);
 }

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Interfaces/IAcuerdoQueryService.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Interfaces/IAcuerdoQueryService.cs
@@ -1,6 +1,12 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Interfaces
+using BackendCConecta.Dominio.Entidades.Acuerdos;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Interfaces;
+
+public interface IAcuerdoQueryService
 {
-    public interface IAcuerdoQueryService
-    {
-    }
+    Task<List<AcuerdosComercial>> ListarAsync();
+    Task<AcuerdosComercial?> ObtenerPorIdAsync(int id);
+    Task<List<AcuerdosComercial>> ObtenerPorUsuarioAsync(int idDatosUsuario);
 }

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Profiles/AcuerdoProfile.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Profiles/AcuerdoProfile.cs
@@ -1,0 +1,33 @@
+using AutoMapper;
+using BackendCConecta.Aplicacion.Modulos.Acuerdos.DTOs;
+using BackendCConecta.Dominio.Entidades.Acuerdos;
+using System;
+
+namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Profiles;
+
+public class AcuerdoProfile : Profile
+{
+    public AcuerdoProfile()
+    {
+        CreateMap<AcuerdosComercial, AcuerdoDto>()
+            .ForMember(d => d.Id, opt => opt.MapFrom(s => s.IdAcuerdo))
+            .ForMember(d => d.FechaInicio, opt => opt.MapFrom(s => s.FechaInicio.ToDateTime(TimeOnly.MinValue)))
+            .ForMember(d => d.FechaFin, opt => opt.MapFrom(s => s.FechaFin.ToDateTime(TimeOnly.MinValue)))
+            .ForMember(d => d.DiasGracia, opt => opt.MapFrom(s => s.DiasGracia ?? 0))
+            .ForMember(d => d.EstadoAcuerdo, opt => opt.MapFrom(s => s.EstadoAcuerdo ?? string.Empty))
+            .ForMember(d => d.Observaciones, opt => opt.MapFrom(s => s.Observaciones ?? string.Empty))
+            .ForMember(d => d.FechaRegistro, opt => opt.MapFrom(s => s.FechaRegistro ?? default));
+
+        CreateMap<CrearAcuerdoDto, AcuerdosComercial>()
+            .ForMember(d => d.IdAcuerdo, opt => opt.Ignore())
+            .ForMember(d => d.FechaInicio, opt => opt.MapFrom(s => DateOnly.FromDateTime(s.FechaInicio)))
+            .ForMember(d => d.FechaFin, opt => opt.MapFrom(s => DateOnly.FromDateTime(s.FechaFin)))
+            .ForMember(d => d.FechaRegistro, opt => opt.Ignore());
+
+        CreateMap<ActualizarAcuerdoDto, AcuerdosComercial>()
+            .ForMember(d => d.IdAcuerdo, opt => opt.MapFrom(s => s.Id))
+            .ForMember(d => d.FechaInicio, opt => opt.MapFrom(s => DateOnly.FromDateTime(s.FechaInicio)))
+            .ForMember(d => d.FechaFin, opt => opt.MapFrom(s => DateOnly.FromDateTime(s.FechaFin)))
+            .ForMember(d => d.FechaRegistro, opt => opt.Ignore());
+    }
+}

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Validadores/CrearAcuerdoValidator.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Validadores/CrearAcuerdoValidator.cs
@@ -1,6 +1,6 @@
 ﻿namespace BackendCConecta.Aplicacion.Modulos.Acuerdos.Validadores
 {
-    public class CrearAcuerdoValidato
+    public class CrearAcuerdoValidator
     {
     }
 }

--- a/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/Acuerdos/AcuerdoRepository.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/Acuerdos/AcuerdoRepository.cs
@@ -1,6 +1,38 @@
-﻿namespace BackendCConecta.Infraestructura.Repositorios.Acuerdos
+using BackendCConecta.Dominio.Entidades.Acuerdos;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace BackendCConecta.Infraestructura.Repositorios.Acuerdos;
+
+public class AcuerdoRepository
 {
-    public class AcuerdoRepository
+    public Task<AcuerdosComercial?> ObtenerPorIdAsync(int id)
     {
+        throw new System.NotImplementedException();
+    }
+
+    public Task<List<AcuerdosComercial>> ListarAsync()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public Task<List<AcuerdosComercial>> ObtenerPorUsuarioAsync(int idDatosUsuario)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public Task<int> CrearAsync(AcuerdosComercial entidad)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public Task<bool> ActualizarAsync(AcuerdosComercial entidad)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public Task<bool> EliminarAsync(int id)
+    {
+        throw new System.NotImplementedException();
     }
 }

--- a/BackendCConecta/BackendCConecta/Infraestructura/Servicios/Acuerdos/AcuerdoComercialCommandService.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Servicios/Acuerdos/AcuerdoComercialCommandService.cs
@@ -1,54 +1,22 @@
-﻿using BackendCConecta.Aplicacion.Modulos.Acuerdos.DTOs;
 using BackendCConecta.Aplicacion.Modulos.Acuerdos.Interfaces;
 using BackendCConecta.Dominio.Entidades.Acuerdos;
 using BackendCConecta.Infraestructura.Repositorios.Acuerdos;
+using System.Threading.Tasks;
 
-namespace BackendCConecta.Infraestructura.Servicios.Acuerdos
+namespace BackendCConecta.Infraestructura.Servicios.Acuerdos;
+
+public class AcuerdoComercialCommandService : IAcuerdoCommandService
 {
-        public class AcuerdoComercialCommandService : IAcuerdoCommandService
-        {
-            private readonly AcuerdoRepository _repository;
+    private readonly AcuerdoRepository _repository;
 
-            public AcuerdoComercialCommandService(AcuerdoRepository repository)
-            {
-                _repository = repository;
-            }
+    public AcuerdoComercialCommandService(AcuerdoRepository repository)
+    {
+        _repository = repository;
+    }
 
-            public async Task<int> CrearAsync(CrearAcuerdoDto dto)
-            {
-                var entidad = new AcuerdoComercial
-                {
-                    IdDatosUsuario = dto.IdDatosUsuario,
-                    IdTarifaAcuerdo = dto.IdTarifaAcuerdo,
-                    FechaInicio = dto.FechaInicio,
-                    FechaFin = dto.FechaFin,
-                    PublicacionesDisponibles = dto.PublicacionesDisponibles,
-                    DiasGracia = dto.DiasGracia,
-                    EstadoAcuerdo = dto.EstadoAcuerdo,
-                    Observaciones = dto.Observaciones
-                };
+    public Task<int> CrearAsync(AcuerdosComercial entidad) => _repository.CrearAsync(entidad);
 
-                return await _repository.CrearAsync(entidad);
-            }
+    public Task<bool> ActualizarAsync(AcuerdosComercial entidad) => _repository.ActualizarAsync(entidad);
 
-            public async Task<bool> ActualizarAsync(int id, ActualizarAcuerdoDto dto)
-            {
-                var entidad = await _repository.ObtenerPorIdAsync(id);
-                if (entidad == null) return false;
-
-                entidad.FechaInicio = dto.FechaInicio;
-                entidad.FechaFin = dto.FechaFin;
-                entidad.PublicacionesDisponibles = dto.PublicacionesDisponibles;
-                entidad.DiasGracia = dto.DiasGracia;
-                entidad.EstadoAcuerdo = dto.EstadoAcuerdo;
-                entidad.Observaciones = dto.Observaciones;
-
-                return await _repository.ActualizarAsync(entidad);
-            }
-
-            public async Task<bool> EliminarAsync(int id)
-            {
-                return await _repository.EliminarAsync(id);
-            }
-        }
+    public Task<bool> EliminarAsync(int id) => _repository.EliminarAsync(id);
 }

--- a/BackendCConecta/BackendCConecta/Infraestructura/Servicios/Acuerdos/AcuerdoComercialQueryService.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Servicios/Acuerdos/AcuerdoComercialQueryService.cs
@@ -1,9 +1,11 @@
-﻿using BackendCConecta.Aplicacion.Modulos.Acuerdos.DTOs;
 using BackendCConecta.Aplicacion.Modulos.Acuerdos.Interfaces;
+using BackendCConecta.Dominio.Entidades.Acuerdos;
 using BackendCConecta.Infraestructura.Repositorios.Acuerdos;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
-namespace BackendCConecta.Infraestructura.Servicios.Acuerdos
-{
+namespace BackendCConecta.Infraestructura.Servicios.Acuerdos;
+
 public class AcuerdoComercialQueryService : IAcuerdoQueryService
 {
     private readonly AcuerdoRepository _repository;
@@ -13,40 +15,10 @@ public class AcuerdoComercialQueryService : IAcuerdoQueryService
         _repository = repository;
     }
 
-    public async Task<AcuerdoDto> ObtenerPorIdAsync(int id)
-    {
-        var entidad = await _repository.ObtenerPorIdAsync(id);
-        return new AcuerdoDto
-        {
-            Id = entidad.Id,
-            IdDatosUsuario = entidad.IdDatosUsuario,
-            IdTarifaAcuerdo = entidad.IdTarifaAcuerdo,
-            FechaInicio = entidad.FechaInicio,
-            FechaFin = entidad.FechaFin,
-            PublicacionesDisponibles = entidad.PublicacionesDisponibles,
-            DiasGracia = entidad.DiasGracia,
-            EstadoAcuerdo = entidad.EstadoAcuerdo,
-            Observaciones = entidad.Observaciones,
-            FechaRegistro = entidad.FechaRegistro
-        };
-    }
+    public Task<List<AcuerdosComercial>> ListarAsync() => _repository.ListarAsync();
 
-    public async Task<List<AcuerdoDto>> ListarAsync()
-    {
-        var lista = await _repository.ListarAsync();
-        return lista.Select(e => new AcuerdoDto
-        {
-            Id = e.Id,
-            IdDatosUsuario = e.IdDatosUsuario,
-            IdTarifaAcuerdo = e.IdTarifaAcuerdo,
-            FechaInicio = e.FechaInicio,
-            FechaFin = e.FechaFin,
-            PublicacionesDisponibles = e.PublicacionesDisponibles,
-            DiasGracia = e.DiasGracia,
-            EstadoAcuerdo = e.EstadoAcuerdo,
-            Observaciones = e.Observaciones,
-            FechaRegistro = e.FechaRegistro
-        }).ToList();
-    }
-}
+    public Task<AcuerdosComercial?> ObtenerPorIdAsync(int id) => _repository.ObtenerPorIdAsync(id);
+
+    public Task<List<AcuerdosComercial>> ObtenerPorUsuarioAsync(int idDatosUsuario) =>
+        _repository.ObtenerPorUsuarioAsync(idDatosUsuario);
 }


### PR DESCRIPTION
## Summary
- add AutoMapper profile for Acuerdos entities and DTOs
- refactor MediatR handlers to use AutoMapper and domain services
- fix PascalCase naming for Acuerdo validator and interfaces

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689543d96864832eaeed7d2b803007bc