### PR TITLE
feat: add campaign services and handlers

### DIFF
--- a/BackendCConecta/BackendCConecta.Tests/BackendCConecta.Tests.csproj
+++ b/BackendCConecta/BackendCConecta.Tests/BackendCConecta.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.17" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BackendCConecta\BackendCConecta.csproj" />
+  </ItemGroup>
+
+</Project>
+

--- a/BackendCConecta/BackendCConecta.Tests/CampaniaServiceTests.cs
+++ b/BackendCConecta/BackendCConecta.Tests/CampaniaServiceTests.cs
@@ -1,0 +1,49 @@
+using BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
+using BackendCConecta.Aplicacion.Modulos.Campanias.Services;
+using BackendCConecta.Dominio.Entidades.Campanias;
+using BackendCConecta.Infraestructura.Persistencia;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace BackendCConecta.Tests;
+
+public class CampaniaServiceTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task ObtenerCampaniasAsync_ReturnsCampaigns()
+    {
+        var context = CreateContext();
+        context.Campanias.Add(new Campania
+        {
+            Titulo = "Campaña 1",
+            TipoCampania = "Tipo",
+            FechaInicio = DateOnly.FromDateTime(DateTime.UtcNow),
+            FechaFin = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)),
+            IdStaff = 1
+        });
+        context.Campanias.Add(new Campania
+        {
+            Titulo = "Campaña 2",
+            TipoCampania = "Tipo",
+            FechaInicio = DateOnly.FromDateTime(DateTime.UtcNow),
+            FechaFin = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)),
+            IdStaff = 1
+        });
+        await context.SaveChangesAsync();
+
+        var service = new CampaniaService(context);
+
+        var result = await service.ObtenerCampaniasAsync();
+
+        Assert.Equal(2, result.Count);
+    }
+}
+

--- a/BackendCConecta/BackendCConecta.Tests/CrearCampaniaHandlerTests.cs
+++ b/BackendCConecta/BackendCConecta.Tests/CrearCampaniaHandlerTests.cs
@@ -1,0 +1,34 @@
+using BackendCConecta.Aplicacion.Modulos.Campanias.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
+using BackendCConecta.Aplicacion.Modulos.Campanias.Handlers;
+using BackendCConecta.Aplicacion.Modulos.Campanias.Interfaces;
+using Moq;
+using Xunit;
+
+namespace BackendCConecta.Tests;
+
+public class CrearCampaniaHandlerTests
+{
+    [Fact]
+    public async Task Handle_DelegatesToService()
+    {
+        var service = new Mock<ICampaniaService>();
+        service.Setup(s => s.CrearCampaniaAsync(It.IsAny<CampaniaDTO>())).ReturnsAsync(1);
+
+        var handler = new CrearCampaniaHandler(service.Object);
+        var command = new CrearCampaniaCommand
+        {
+            Titulo = "Prueba",
+            TipoCampania = "Tipo",
+            FechaInicio = DateOnly.FromDateTime(DateTime.UtcNow),
+            FechaFin = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)),
+            IdStaff = 1
+        };
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(1, result);
+        service.Verify(s => s.CrearCampaniaAsync(It.IsAny<CampaniaDTO>()), Times.Once);
+    }
+}
+

--- a/BackendCConecta/BackendCConecta.sln
+++ b/BackendCConecta/BackendCConecta.sln
@@ -1,22 +1,28 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.12.35527.113 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BackendCConecta", "BackendCConecta\BackendCConecta.csproj", "{1C875650-1480-4A21-B8F7-62536A3AAC0D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BackendCConecta", "BackendCConecta\\BackendCConecta.csproj", "{1C875650-1480-4A21-B8F7-62536A3AAC0D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BackendCConecta.Tests", "BackendCConecta.Tests\\BackendCConecta.Tests.csproj", "{B22166AD-79B4-4FD0-AA41-7265C6658739}"
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{1C875650-1480-4A21-B8F7-62536A3AAC0D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1C875650-1480-4A21-B8F7-62536A3AAC0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1C875650-1480-4A21-B8F7-62536A3AAC0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1C875650-1480-4A21-B8F7-62536A3AAC0D}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|Any CPU = Debug|Any CPU
+                Release|Any CPU = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {1C875650-1480-4A21-B8F7-62536A3AAC0D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {1C875650-1480-4A21-B8F7-62536A3AAC0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {1C875650-1480-4A21-B8F7-62536A3AAC0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {1C875650-1480-4A21-B8F7-62536A3AAC0D}.Release|Any CPU.Build.0 = Release|Any CPU
+                {B22166AD-79B4-4FD0-AA41-7265C6658739}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {B22166AD-79B4-4FD0-AA41-7265C6658739}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {B22166AD-79B4-4FD0-AA41-7265C6658739}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B22166AD-79B4-4FD0-AA41-7265C6658739}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+        EndGlobalSection
 EndGlobal
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Comandos/CrearCampaniaCommand.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Comandos/CrearCampaniaCommand.cs
@@ -1,6 +1,27 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Campañas.Comandos
+using BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
+using MediatR;
+
+namespace BackendCConecta.Aplicacion.Modulos.Campanias.Comandos;
+
+/// <summary>
+/// Command used to create a new campaign.
+/// </summary>
+public class CrearCampaniaCommand : IRequest<int>
 {
-    public class CrearCampaniaCommand
-    {
-    }
+    public string Titulo { get; set; } = string.Empty;
+
+    public string? Descripcion { get; set; }
+
+    public string TipoCampania { get; set; } = string.Empty;
+
+    public DateOnly FechaInicio { get; set; }
+
+    public DateOnly FechaFin { get; set; }
+
+    public string? Estado { get; set; }
+
+    public int? IdUbicacion { get; set; }
+
+    public int IdStaff { get; set; }
 }
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Consultas/ObtenerCampaniasQuery.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Consultas/ObtenerCampaniasQuery.cs
@@ -1,6 +1,12 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Campañas.Consultas
+using BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
+using MediatR;
+
+namespace BackendCConecta.Aplicacion.Modulos.Campanias.Consultas;
+
+/// <summary>
+/// Query to retrieve all campaigns.
+/// </summary>
+public class ObtenerCampaniasQuery : IRequest<IReadOnlyList<CampaniaDTO>>
 {
-    public class ObtenerCampaniasQuery
-    {
-    }
 }
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/DTOs/CampaniaDTO.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/DTOs/CampaniaDTO.cs
@@ -1,6 +1,26 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Campañas.DTOs
+namespace BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
+
+/// <summary>
+/// Data transfer object representing a campaign.
+/// </summary>
+public class CampaniaDTO
 {
-    public class CampaniaDTO
-    {
-    }
+    public int IdCampania { get; set; }
+
+    public string Titulo { get; set; } = string.Empty;
+
+    public string? Descripcion { get; set; }
+
+    public string TipoCampania { get; set; } = string.Empty;
+
+    public DateOnly FechaInicio { get; set; }
+
+    public DateOnly FechaFin { get; set; }
+
+    public string? Estado { get; set; }
+
+    public int? IdUbicacion { get; set; }
+
+    public int IdStaff { get; set; }
 }
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Handlers/CrearCampaniaHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Handlers/CrearCampaniaHandler.cs
@@ -1,6 +1,38 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Campañas.Handlers
+using BackendCConecta.Aplicacion.Modulos.Campanias.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
+using BackendCConecta.Aplicacion.Modulos.Campanias.Interfaces;
+using MediatR;
+
+namespace BackendCConecta.Aplicacion.Modulos.Campanias.Handlers;
+
+/// <summary>
+/// Handler responsible for creating campaigns.
+/// </summary>
+public class CrearCampaniaHandler : IRequestHandler<CrearCampaniaCommand, int>
 {
-    public class CrearCampaniaHandler
+    private readonly ICampaniaService _campaniaService;
+
+    public CrearCampaniaHandler(ICampaniaService campaniaService)
     {
+        _campaniaService = campaniaService;
+    }
+
+    /// <inheritdoc />
+    public Task<int> Handle(CrearCampaniaCommand request, CancellationToken cancellationToken)
+    {
+        var dto = new CampaniaDTO
+        {
+            Titulo = request.Titulo,
+            Descripcion = request.Descripcion,
+            TipoCampania = request.TipoCampania,
+            FechaInicio = request.FechaInicio,
+            FechaFin = request.FechaFin,
+            Estado = request.Estado,
+            IdUbicacion = request.IdUbicacion,
+            IdStaff = request.IdStaff
+        };
+
+        return _campaniaService.CrearCampaniaAsync(dto);
     }
 }
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Handlers/ObtenerCampaniasHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Handlers/ObtenerCampaniasHandler.cs
@@ -1,0 +1,24 @@
+using BackendCConecta.Aplicacion.Modulos.Campanias.Consultas;
+using BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
+using BackendCConecta.Aplicacion.Modulos.Campanias.Interfaces;
+using MediatR;
+
+namespace BackendCConecta.Aplicacion.Modulos.Campanias.Handlers;
+
+/// <summary>
+/// Handler that delegates retrieval of campaigns to the service layer.
+/// </summary>
+public class ObtenerCampaniasHandler : IRequestHandler<ObtenerCampaniasQuery, IReadOnlyList<CampaniaDTO>>
+{
+    private readonly ICampaniaService _campaniaService;
+
+    public ObtenerCampaniasHandler(ICampaniaService campaniaService)
+    {
+        _campaniaService = campaniaService;
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<CampaniaDTO>> Handle(ObtenerCampaniasQuery request, CancellationToken cancellationToken)
+        => _campaniaService.ObtenerCampaniasAsync();
+}
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Interfaces/ICampaniaService.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Interfaces/ICampaniaService.cs
@@ -1,6 +1,23 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Campanias.Interfaces
+using BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
+
+namespace BackendCConecta.Aplicacion.Modulos.Campanias.Interfaces;
+
+/// <summary>
+/// Define operations related to campaign management.
+/// </summary>
+public interface ICampaniaService
 {
-    public interface ICampaniaService
-    {
-    }
+    /// <summary>
+    /// Persists a new campaign.
+    /// </summary>
+    /// <param name="campania">Information for the campaign to create.</param>
+    /// <returns>The identifier of the created campaign.</returns>
+    Task<int> CrearCampaniaAsync(CampaniaDTO campania);
+
+    /// <summary>
+    /// Retrieves all campaigns registered in the system.
+    /// </summary>
+    /// <returns>A read only collection of campaigns.</returns>
+    Task<IReadOnlyList<CampaniaDTO>> ObtenerCampaniasAsync();
 }
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Services/CampaniaService.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Services/CampaniaService.cs
@@ -1,0 +1,62 @@
+using BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
+using BackendCConecta.Aplicacion.Modulos.Campanias.Interfaces;
+using BackendCConecta.Dominio.Entidades.Campanias;
+using BackendCConecta.Infraestructura.Persistencia;
+using Microsoft.EntityFrameworkCore;
+
+namespace BackendCConecta.Aplicacion.Modulos.Campanias.Services;
+
+/// <summary>
+/// Service implementation responsible for campaign business logic.
+/// </summary>
+public class CampaniaService : ICampaniaService
+{
+    private readonly AppDbContext _context;
+
+    public CampaniaService(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CrearCampaniaAsync(CampaniaDTO campania)
+    {
+        var entity = new Campania
+        {
+            Titulo = campania.Titulo,
+            Descripcion = campania.Descripcion,
+            TipoCampania = campania.TipoCampania,
+            FechaInicio = campania.FechaInicio,
+            FechaFin = campania.FechaFin,
+            Estado = campania.Estado,
+            IdUbicacion = campania.IdUbicacion,
+            IdStaff = campania.IdStaff,
+            FechaRegistro = DateTime.UtcNow
+        };
+
+        _context.Campanias.Add(entity);
+        await _context.SaveChangesAsync();
+
+        return entity.IdCampania;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CampaniaDTO>> ObtenerCampaniasAsync()
+    {
+        return await _context.Campanias
+            .Select(c => new CampaniaDTO
+            {
+                IdCampania = c.IdCampania,
+                Titulo = c.Titulo,
+                Descripcion = c.Descripcion,
+                TipoCampania = c.TipoCampania,
+                FechaInicio = c.FechaInicio,
+                FechaFin = c.FechaFin,
+                Estado = c.Estado,
+                IdUbicacion = c.IdUbicacion,
+                IdStaff = c.IdStaff
+            })
+            .ToListAsync();
+    }
+}
+

--- a/BackendCConecta/BackendCConecta/Program.cs
+++ b/BackendCConecta/BackendCConecta/Program.cs
@@ -11,6 +11,10 @@ using Microsoft.Extensions.Options;
 using BackendCConecta.Aplicacion.InterfacesGenerales;// o donde esté IUsuarioService
 using BackendCConecta.Infraestructura.Servicios;// o donde esté UsuarioService
 
+// 📆 Campañas
+using BackendCConecta.Aplicacion.Modulos.Campanias.Interfaces;
+using BackendCConecta.Aplicacion.Modulos.Campanias.Services;
+
 // ?? Autenticación
 using BackendCConecta.Aplicacion.Modulos.Auth.Interfaces;
 using BackendCConecta.Aplicacion.Modulos.Auth.Servicios;
@@ -130,6 +134,7 @@ builder.Services.AddScoped<IDatosPersonaRepository, DatosPersonaRepository>();
 builder.Services.AddScoped<IDatosPersonaQueryService, DatosPersonaQueryService>();
 builder.Services.AddScoped<IDatosEmpresaRepository, DatosEmpresaRepository>();
 builder.Services.AddScoped<IDatosEmpresaQueryService, DatosEmpresaQueryService>();
+builder.Services.AddScoped<ICampaniaService, CampaniaService>();
 // 🗂️ FluentValidation
 builder.Services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
 


### PR DESCRIPTION
## Summary
- implement `CampaniaService` to centralize campaign business logic
- refactor handlers to delegate to the new service
- register service in DI and add unit tests

## Testing
- `dotnet test BackendCConecta/BackendCConecta.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689546810bb8832e830d3605f4db966c