### PR TITLE
fix: align repository namespace with folder structure

### DIFF
--- a/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/Ubicationes/LugaresReferenciaRepository.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/Ubicationes/LugaresReferenciaRepository.cs
@@ -1,6 +1,10 @@
-﻿namespace BackendCConecta.Infraestructura.Repositorios.LugaresReferencia
+namespace BackendCConecta.Infraestructura.Repositorios.Ubicationes
 {
+    /// <summary>
+    /// Repository for managing reference location entities.
+    /// </summary>
     public class LugaresReferenciaRepository
     {
     }
 }
+


### PR DESCRIPTION
## Summary
- align namespace of `LugaresReferenciaRepository` with its folder structure
- add XML documentation to repository class

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68954bbaf8b8832e9241889763e35e9b