### PR TITLE
Refactor repositories to async with proper SaveChangesAsync usage

### DIFF
--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Handlers/EliminarAcuerdoHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Acuerdos/Handlers/EliminarAcuerdoHandler.cs
@@ -13,8 +13,8 @@ public class EliminarAcuerdoHandler : IRequestHandler<EliminarAcuerdoComercialCo
         _service = service;
     }
 
-    public Task<bool> Handle(EliminarAcuerdoComercialCommand request, CancellationToken cancellationToken)
+    public async Task<bool> Handle(EliminarAcuerdoComercialCommand request, CancellationToken cancellationToken)
     {
-        return _service.EliminarAsync(request.Id);
+        return await _service.EliminarAsync(request.Id);
     }
 }

--- a/BackendCConecta/BackendCConecta/Dominio/Repositorios/IAcuerdoRepository.cs
+++ b/BackendCConecta/BackendCConecta/Dominio/Repositorios/IAcuerdoRepository.cs
@@ -1,6 +1,15 @@
-﻿namespace BackendCConecta.Dominio.Repositorios
+using BackendCConecta.Dominio.Entidades.Acuerdos;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace BackendCConecta.Dominio.Repositorios;
+
+public interface IAcuerdoRepository
 {
-    public class IAcuerdoRepository
-    {
-    }
+    Task<AcuerdosComercial?> ObtenerPorIdAsync(int id);
+    Task<List<AcuerdosComercial>> ListarAsync();
+    Task<List<AcuerdosComercial>> ObtenerPorUsuarioAsync(int idDatosUsuario);
+    Task<int> CrearAsync(AcuerdosComercial entidad);
+    Task<bool> ActualizarAsync(AcuerdosComercial entidad);
+    Task<bool> EliminarAsync(int id);
 }

--- a/BackendCConecta/BackendCConecta/Dominio/Repositorios/ILugaresReferenciaRepository.cs
+++ b/BackendCConecta/BackendCConecta/Dominio/Repositorios/ILugaresReferenciaRepository.cs
@@ -1,6 +1,14 @@
-﻿namespace BackendCConecta.Dominio.Repositorios
+using BackendCConecta.Dominio.Entidades.UbicacionSistema;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace BackendCConecta.Dominio.Repositorios;
+
+public interface ILugaresReferenciaRepository
 {
-    public class ILugaresReferenciaRepository
-    {
-    }
+    Task<LugaresReferencia?> ObtenerPorIdAsync(int id);
+    Task<IEnumerable<LugaresReferencia>> ListarAsync();
+    Task InsertarAsync(LugaresReferencia entidad);
+    Task ActualizarAsync(LugaresReferencia entidad);
+    Task EliminarAsync(LugaresReferencia entidad);
 }

--- a/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/Acuerdos/AcuerdoRepository.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/Acuerdos/AcuerdoRepository.cs
@@ -1,38 +1,64 @@
 using BackendCConecta.Dominio.Entidades.Acuerdos;
+using BackendCConecta.Dominio.Repositorios;
+using BackendCConecta.Infraestructura.Persistencia;
+using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace BackendCConecta.Infraestructura.Repositorios.Acuerdos;
 
-public class AcuerdoRepository
+public class AcuerdoRepository : IAcuerdoRepository
 {
-    public Task<AcuerdosComercial?> ObtenerPorIdAsync(int id)
+    private readonly AppDbContext _context;
+
+    public AcuerdoRepository(AppDbContext context)
     {
-        throw new System.NotImplementedException();
+        _context = context;
     }
 
-    public Task<List<AcuerdosComercial>> ListarAsync()
+    public async Task<AcuerdosComercial?> ObtenerPorIdAsync(int id)
     {
-        throw new System.NotImplementedException();
+        return await _context.AcuerdosComerciales.FindAsync(id);
     }
 
-    public Task<List<AcuerdosComercial>> ObtenerPorUsuarioAsync(int idDatosUsuario)
+    public async Task<List<AcuerdosComercial>> ListarAsync()
     {
-        throw new System.NotImplementedException();
+        return await _context.AcuerdosComerciales
+            .AsNoTracking()
+            .ToListAsync();
     }
 
-    public Task<int> CrearAsync(AcuerdosComercial entidad)
+    public async Task<List<AcuerdosComercial>> ObtenerPorUsuarioAsync(int idDatosUsuario)
     {
-        throw new System.NotImplementedException();
+        return await _context.AcuerdosComerciales
+            .AsNoTracking()
+            .Where(a => a.IdDatosUsuario == idDatosUsuario)
+            .ToListAsync();
     }
 
-    public Task<bool> ActualizarAsync(AcuerdosComercial entidad)
+    public async Task<int> CrearAsync(AcuerdosComercial entidad)
     {
-        throw new System.NotImplementedException();
+        await _context.AcuerdosComerciales.AddAsync(entidad);
+        await _context.SaveChangesAsync();
+        return entidad.IdAcuerdo;
     }
 
-    public Task<bool> EliminarAsync(int id)
+    public async Task<bool> ActualizarAsync(AcuerdosComercial entidad)
     {
-        throw new System.NotImplementedException();
+        _context.AcuerdosComerciales.Update(entidad);
+        return await _context.SaveChangesAsync() > 0;
+    }
+
+    public async Task<bool> EliminarAsync(int id)
+    {
+        var entidad = await _context.AcuerdosComerciales.FindAsync(id);
+        if (entidad == null)
+        {
+            return false;
+        }
+
+        _context.AcuerdosComerciales.Remove(entidad);
+        return await _context.SaveChangesAsync() > 0;
     }
 }

--- a/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/Ubicationes/LugaresReferenciaRepository.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/Ubicationes/LugaresReferenciaRepository.cs
@@ -1,6 +1,48 @@
-﻿namespace BackendCConecta.Infraestructura.Repositorios.LugaresReferencia
+using BackendCConecta.Dominio.Entidades.UbicacionSistema;
+using BackendCConecta.Dominio.Repositorios;
+using BackendCConecta.Infraestructura.Persistencia;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace BackendCConecta.Infraestructura.Repositorios.Ubicationes;
+
+public class LugaresReferenciaRepository : ILugaresReferenciaRepository
 {
-    public class LugaresReferenciaRepository
+    private readonly AppDbContext _context;
+
+    public LugaresReferenciaRepository(AppDbContext context)
     {
+        _context = context;
+    }
+
+    public async Task<LugaresReferencia?> ObtenerPorIdAsync(int id)
+    {
+        return await _context.LugaresReferencias.FindAsync(id);
+    }
+
+    public async Task<IEnumerable<LugaresReferencia>> ListarAsync()
+    {
+        return await _context.LugaresReferencias
+            .AsNoTracking()
+            .ToListAsync();
+    }
+
+    public async Task InsertarAsync(LugaresReferencia entidad)
+    {
+        await _context.LugaresReferencias.AddAsync(entidad);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task ActualizarAsync(LugaresReferencia entidad)
+    {
+        _context.LugaresReferencias.Update(entidad);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task EliminarAsync(LugaresReferencia entidad)
+    {
+        _context.LugaresReferencias.Remove(entidad);
+        await _context.SaveChangesAsync();
     }
 }

--- a/BackendCConecta/BackendCConecta/Infraestructura/Servicios/Acuerdos/AcuerdoComercialCommandService.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Servicios/Acuerdos/AcuerdoComercialCommandService.cs
@@ -1,15 +1,15 @@
 using BackendCConecta.Aplicacion.Modulos.Acuerdos.Interfaces;
 using BackendCConecta.Dominio.Entidades.Acuerdos;
-using BackendCConecta.Infraestructura.Repositorios.Acuerdos;
+using BackendCConecta.Dominio.Repositorios;
 using System.Threading.Tasks;
 
 namespace BackendCConecta.Infraestructura.Servicios.Acuerdos;
 
 public class AcuerdoComercialCommandService : IAcuerdoCommandService
 {
-    private readonly AcuerdoRepository _repository;
+    private readonly IAcuerdoRepository _repository;
 
-    public AcuerdoComercialCommandService(AcuerdoRepository repository)
+    public AcuerdoComercialCommandService(IAcuerdoRepository repository)
     {
         _repository = repository;
     }

--- a/BackendCConecta/BackendCConecta/Infraestructura/Servicios/Acuerdos/AcuerdoComercialQueryService.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Servicios/Acuerdos/AcuerdoComercialQueryService.cs
@@ -1,6 +1,6 @@
 using BackendCConecta.Aplicacion.Modulos.Acuerdos.Interfaces;
 using BackendCConecta.Dominio.Entidades.Acuerdos;
-using BackendCConecta.Infraestructura.Repositorios.Acuerdos;
+using BackendCConecta.Dominio.Repositorios;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -8,9 +8,9 @@ namespace BackendCConecta.Infraestructura.Servicios.Acuerdos;
 
 public class AcuerdoComercialQueryService : IAcuerdoQueryService
 {
-    private readonly AcuerdoRepository _repository;
+    private readonly IAcuerdoRepository _repository;
 
-    public AcuerdoComercialQueryService(AcuerdoRepository repository)
+    public AcuerdoComercialQueryService(IAcuerdoRepository repository)
     {
         _repository = repository;
     }


### PR DESCRIPTION
## Summary
- add async interfaces for agreements and reference locations repositories
- implement async EF Core repositories using SaveChangesAsync
- await repository operations in handlers and wire services to interfaces

## Testing
- `dotnet test BackendCConecta/BackendCConecta.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(failed: repository InRelease not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68954bb7e830832e8dc3e7d0bc7fea72