### PR TITLE
Split campaign service interfaces

### DIFF
--- a/BackendCConecta/BackendCConecta.Tests/CrearCampaniaHandlerTests.cs
+++ b/BackendCConecta/BackendCConecta.Tests/CrearCampaniaHandlerTests.cs
@@ -12,7 +12,7 @@ public class CrearCampaniaHandlerTests
     [Fact]
     public async Task Handle_DelegatesToService()
     {
-        var service = new Mock<ICampaniaService>();
+        var service = new Mock<ICampaniaCommandService>();
         service.Setup(s => s.CrearCampaniaAsync(It.IsAny<CampaniaDTO>())).ReturnsAsync(1);
 
         var handler = new CrearCampaniaHandler(service.Object);

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Handlers/CrearCampaniaHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Handlers/CrearCampaniaHandler.cs
@@ -10,11 +10,11 @@ namespace BackendCConecta.Aplicacion.Modulos.Campanias.Handlers;
 /// </summary>
 public class CrearCampaniaHandler : IRequestHandler<CrearCampaniaCommand, int>
 {
-    private readonly ICampaniaService _campaniaService;
+    private readonly ICampaniaCommandService _campaniaCommandService;
 
-    public CrearCampaniaHandler(ICampaniaService campaniaService)
+    public CrearCampaniaHandler(ICampaniaCommandService campaniaCommandService)
     {
-        _campaniaService = campaniaService;
+        _campaniaCommandService = campaniaCommandService;
     }
 
     /// <inheritdoc />
@@ -32,7 +32,7 @@ public class CrearCampaniaHandler : IRequestHandler<CrearCampaniaCommand, int>
             IdStaff = request.IdStaff
         };
 
-        return _campaniaService.CrearCampaniaAsync(dto);
+        return _campaniaCommandService.CrearCampaniaAsync(dto);
     }
 }
 

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Handlers/ObtenerCampaniasHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Handlers/ObtenerCampaniasHandler.cs
@@ -10,15 +10,15 @@ namespace BackendCConecta.Aplicacion.Modulos.Campanias.Handlers;
 /// </summary>
 public class ObtenerCampaniasHandler : IRequestHandler<ObtenerCampaniasQuery, IReadOnlyList<CampaniaDTO>>
 {
-    private readonly ICampaniaService _campaniaService;
+    private readonly ICampaniaQueryService _campaniaQueryService;
 
-    public ObtenerCampaniasHandler(ICampaniaService campaniaService)
+    public ObtenerCampaniasHandler(ICampaniaQueryService campaniaQueryService)
     {
-        _campaniaService = campaniaService;
+        _campaniaQueryService = campaniaQueryService;
     }
 
     /// <inheritdoc />
     public Task<IReadOnlyList<CampaniaDTO>> Handle(ObtenerCampaniasQuery request, CancellationToken cancellationToken)
-        => _campaniaService.ObtenerCampaniasAsync();
+        => _campaniaQueryService.ObtenerCampaniasAsync();
 }
 

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Interfaces/ICampaniaCommandService.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Interfaces/ICampaniaCommandService.cs
@@ -1,0 +1,17 @@
+using BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
+
+namespace BackendCConecta.Aplicacion.Modulos.Campanias.Interfaces;
+
+/// <summary>
+/// Defines operations related to modifying campaign data.
+/// </summary>
+public interface ICampaniaCommandService
+{
+    /// <summary>
+    /// Persists a new campaign.
+    /// </summary>
+    /// <param name="campania">Information for the campaign to create.</param>
+    /// <returns>The identifier of the created campaign.</returns>
+    Task<int> CrearCampaniaAsync(CampaniaDTO campania);
+}
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Interfaces/ICampaniaQueryService.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Interfaces/ICampaniaQueryService.cs
@@ -3,17 +3,10 @@ using BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
 namespace BackendCConecta.Aplicacion.Modulos.Campanias.Interfaces;
 
 /// <summary>
-/// Define operations related to campaign management.
+/// Defines operations related to retrieving campaign data.
 /// </summary>
-public interface ICampaniaService
+public interface ICampaniaQueryService
 {
-    /// <summary>
-    /// Persists a new campaign.
-    /// </summary>
-    /// <param name="campania">Information for the campaign to create.</param>
-    /// <returns>The identifier of the created campaign.</returns>
-    Task<int> CrearCampaniaAsync(CampaniaDTO campania);
-
     /// <summary>
     /// Retrieves all campaigns registered in the system.
     /// </summary>

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Services/CampaniaService.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Services/CampaniaService.cs
@@ -9,7 +9,7 @@ namespace BackendCConecta.Aplicacion.Modulos.Campanias.Services;
 /// <summary>
 /// Service implementation responsible for campaign business logic.
 /// </summary>
-public class CampaniaService : ICampaniaService
+public class CampaniaService : ICampaniaCommandService, ICampaniaQueryService
 {
     private readonly AppDbContext _context;
 

--- a/BackendCConecta/BackendCConecta/Program.cs
+++ b/BackendCConecta/BackendCConecta/Program.cs
@@ -134,7 +134,8 @@ builder.Services.AddScoped<IDatosPersonaRepository, DatosPersonaRepository>();
 builder.Services.AddScoped<IDatosPersonaQueryService, DatosPersonaQueryService>();
 builder.Services.AddScoped<IDatosEmpresaRepository, DatosEmpresaRepository>();
 builder.Services.AddScoped<IDatosEmpresaQueryService, DatosEmpresaQueryService>();
-builder.Services.AddScoped<ICampaniaService, CampaniaService>();
+builder.Services.AddScoped<ICampaniaCommandService, CampaniaService>();
+builder.Services.AddScoped<ICampaniaQueryService, CampaniaService>();
 // 🗂️ FluentValidation
 builder.Services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
 


### PR DESCRIPTION
## Summary
- introduce command and query interfaces for campaign services
- refactor campaign handlers to depend on role-specific interfaces
- register new interfaces in DI container

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68954d6d46a0832eb878986a29b445c0