### PR TITLE
Add validators and permission checks for role assignments

### DIFF
--- a/BackendCConecta/BackendCConecta/Aplicacion/InterfacesGenerales/ICurrentUserService.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/InterfacesGenerales/ICurrentUserService.cs
@@ -1,6 +1,15 @@
-﻿namespace BackendCConecta.Aplicacion.InterfacesGenerales
+namespace BackendCConecta.Aplicacion.InterfacesGenerales;
+
+/// <summary>
+/// Servicio para obtener información del usuario autenticado.
+/// </summary>
+public interface ICurrentUserService
 {
-    public interface ICurrentUserService
-    {
-    }
+    /// <summary>
+    /// Determina si el usuario actual posee el rol especificado.
+    /// </summary>
+    /// <param name="role">Nombre del rol a verificar.</param>
+    /// <returns><c>true</c> si el usuario tiene el rol; de lo contrario, <c>false</c>.</returns>
+    bool HasRole(string role);
 }
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Comandos/AsignarRolCommand.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Comandos/AsignarRolCommand.cs
@@ -1,0 +1,21 @@
+using MediatR;
+
+namespace BackendCConecta.Aplicacion.Modulos.Roles.Comandos
+{
+    /// <summary>
+    /// Comando para asignar un rol a un usuario.
+    /// </summary>
+    public class AsignarRolCommand : IRequest<bool>
+    {
+        /// <summary>
+        /// Identificador del usuario al que se le asignará el rol.
+        /// </summary>
+        public int IdDatosUsuario { get; set; }
+
+        /// <summary>
+        /// Identificador del rol a asignar.
+        /// </summary>
+        public int IdRol { get; set; }
+    }
+}
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Comandos/RemoverRolCommand.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Comandos/RemoverRolCommand.cs
@@ -1,0 +1,21 @@
+using MediatR;
+
+namespace BackendCConecta.Aplicacion.Modulos.Roles.Comandos
+{
+    /// <summary>
+    /// Comando para remover un rol previamente asignado a un usuario.
+    /// </summary>
+    public class RemoverRolCommand : IRequest<bool>
+    {
+        /// <summary>
+        /// Identificador del usuario al que se le removerá el rol.
+        /// </summary>
+        public int IdDatosUsuario { get; set; }
+
+        /// <summary>
+        /// Identificador del rol a remover.
+        /// </summary>
+        public int IdRol { get; set; }
+    }
+}
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Handlers/AsignarRolHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Handlers/AsignarRolHandler.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using BackendCConecta.Aplicacion.InterfacesGenerales;
+using BackendCConecta.Aplicacion.Modulos.Roles.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Roles.Interfaces;
+
+namespace BackendCConecta.Aplicacion.Modulos.Roles.Handlers
+{
+    /// <summary>
+    /// Maneja la asignación de roles a los usuarios.
+    /// </summary>
+    public class AsignarRolHandler : IRequestHandler<AsignarRolCommand, bool>
+    {
+        private readonly IRolCommandService _rolCommandService;
+        private readonly ICurrentUserService _currentUserService;
+
+        public AsignarRolHandler(IRolCommandService rolCommandService, ICurrentUserService currentUserService)
+        {
+            _rolCommandService = rolCommandService;
+            _currentUserService = currentUserService;
+        }
+
+        public async Task<bool> Handle(AsignarRolCommand request, CancellationToken cancellationToken)
+        {
+            if (!_currentUserService.HasRole("administrador"))
+            {
+                throw new UnauthorizedAccessException("Usuario sin permisos para asignar roles.");
+            }
+
+            return await _rolCommandService.AsignarRolAsync(request.IdDatosUsuario, request.IdRol);
+        }
+    }
+}
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Handlers/RemoverRolHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Handlers/RemoverRolHandler.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using BackendCConecta.Aplicacion.InterfacesGenerales;
+using BackendCConecta.Aplicacion.Modulos.Roles.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Roles.Interfaces;
+
+namespace BackendCConecta.Aplicacion.Modulos.Roles.Handlers
+{
+    /// <summary>
+    /// Maneja la eliminación de roles asignados a los usuarios.
+    /// </summary>
+    public class RemoverRolHandler : IRequestHandler<RemoverRolCommand, bool>
+    {
+        private readonly IRolCommandService _rolCommandService;
+        private readonly ICurrentUserService _currentUserService;
+
+        public RemoverRolHandler(IRolCommandService rolCommandService, ICurrentUserService currentUserService)
+        {
+            _rolCommandService = rolCommandService;
+            _currentUserService = currentUserService;
+        }
+
+        public async Task<bool> Handle(RemoverRolCommand request, CancellationToken cancellationToken)
+        {
+            if (!_currentUserService.HasRole("administrador"))
+            {
+                throw new UnauthorizedAccessException("Usuario sin permisos para modificar roles.");
+            }
+
+            return await _rolCommandService.RemoverRolAsync(request.IdDatosUsuario, request.IdRol);
+        }
+    }
+}
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Handlers/RolHelper.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Handlers/RolHelper.cs
@@ -1,6 +1,0 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Roles.Handlers
-{
-    public class RolHelper
-    {
-    }
-}

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Interfaces/IRolCommandService.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Interfaces/IRolCommandService.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+
+namespace BackendCConecta.Aplicacion.Modulos.Roles.Interfaces
+{
+    /// <summary>
+    /// Define las operaciones para gestionar asignaciones de roles.
+    /// </summary>
+    public interface IRolCommandService
+    {
+        /// <summary>
+        /// Asigna un rol a un usuario.
+        /// </summary>
+        Task<bool> AsignarRolAsync(int idDatosUsuario, int idRol);
+
+        /// <summary>
+        /// Remueve un rol de un usuario.
+        /// </summary>
+        Task<bool> RemoverRolAsync(int idDatosUsuario, int idRol);
+    }
+}
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Validadores/AsignarRolCommandValidator.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Validadores/AsignarRolCommandValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+using BackendCConecta.Aplicacion.Modulos.Roles.Comandos;
+
+namespace BackendCConecta.Aplicacion.Modulos.Roles.Validadores
+{
+    public class AsignarRolCommandValidator : AbstractValidator<AsignarRolCommand>
+    {
+        public AsignarRolCommandValidator()
+        {
+            RuleFor(x => x.IdDatosUsuario)
+                .GreaterThan(0).WithMessage("El usuario es obligatorio.");
+
+            RuleFor(x => x.IdRol)
+                .GreaterThan(0).WithMessage("El rol es obligatorio.");
+        }
+    }
+}
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Validadores/RemoverRolCommandValidator.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Validadores/RemoverRolCommandValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+using BackendCConecta.Aplicacion.Modulos.Roles.Comandos;
+
+namespace BackendCConecta.Aplicacion.Modulos.Roles.Validadores
+{
+    public class RemoverRolCommandValidator : AbstractValidator<RemoverRolCommand>
+    {
+        public RemoverRolCommandValidator()
+        {
+            RuleFor(x => x.IdDatosUsuario)
+                .GreaterThan(0).WithMessage("El usuario es obligatorio.");
+
+            RuleFor(x => x.IdRol)
+                .GreaterThan(0).WithMessage("El rol es obligatorio.");
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add HasRole method to current user service
- create role assignment commands with FluentValidation rules
- enforce admin-only role assignment in new handlers

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68954e6b1ad8832ea6d26abee49d53fe