### PR TITLE
feat: add transaction scope service and pipeline

### DIFF
--- a/BackendCConecta/BackendCConecta/Aplicacion/Comportamientos/TransactionBehavior.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Comportamientos/TransactionBehavior.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using BackendCConecta.Aplicacion.InterfacesGenerales;
+
+namespace BackendCConecta.Aplicacion.Comportamientos
+{
+    /// <summary>
+    /// Comportamiento de pipeline que envuelve comandos en una transacción.
+    /// </summary>
+    public class TransactionBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+        where TRequest : IRequest<TResponse>
+    {
+        private readonly ITransactionService _transactionService;
+        private readonly ILogger<TransactionBehavior<TRequest, TResponse>> _logger;
+
+        public TransactionBehavior(ITransactionService transactionService, ILogger<TransactionBehavior<TRequest, TResponse>> logger)
+        {
+            _transactionService = transactionService;
+            _logger = logger;
+        }
+
+        public Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+        {
+            var requestName = typeof(TRequest).Name;
+            var isCommand = requestName.EndsWith("Command", StringComparison.InvariantCulture);
+
+            if (!isCommand)
+            {
+                return next();
+            }
+
+            using (_logger.BeginScope(new Dictionary<string, object> { ["RequestName"] = requestName }))
+            {
+                return _transactionService.ExecuteAsync(async () =>
+                {
+                    _logger.LogInformation("Starting transaction for {RequestName}", requestName);
+                    var response = await next();
+                    _logger.LogInformation("Completed transaction for {RequestName}", requestName);
+                    return response;
+                }, cancellationToken);
+            }
+        }
+    }
+}
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/InterfacesGenerales/ITransactionService.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/InterfacesGenerales/ITransactionService.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BackendCConecta.Aplicacion.InterfacesGenerales
+{
+    /// <summary>
+    /// Abstrae la creación y finalización de <see cref="System.Transactions.TransactionScope"/>.
+    /// </summary>
+    public interface ITransactionService
+    {
+        /// <summary>
+        /// Ejecuta una operación dentro de una transacción y devuelve un resultado.
+        /// </summary>
+        /// <typeparam name="T">Tipo del resultado.</typeparam>
+        /// <param name="action">Función a ejecutar.</param>
+        /// <param name="cancellationToken">Token de cancelación.</param>
+        Task<T> ExecuteAsync<T>(Func<Task<T>> action, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Ejecuta una operación dentro de una transacción.
+        /// </summary>
+        /// <param name="action">Función a ejecutar.</param>
+        /// <param name="cancellationToken">Token de cancelación.</param>
+        Task ExecuteAsync(Func<Task> action, CancellationToken cancellationToken = default);
+    }
+}
+

--- a/BackendCConecta/BackendCConecta/Infraestructura/Servicios/TransactionService.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Servicios/TransactionService.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+using BackendCConecta.Aplicacion.InterfacesGenerales;
+using Microsoft.Extensions.Logging;
+
+namespace BackendCConecta.Infraestructura.Servicios
+{
+    /// <summary>
+    /// Implementación basada en <see cref="TransactionScope"/> para manejar transacciones.
+    /// </summary>
+    public class TransactionService : ITransactionService
+    {
+        private readonly ILogger<TransactionService> _logger;
+
+        public TransactionService(ILogger<TransactionService> logger)
+        {
+            _logger = logger;
+        }
+
+        public async Task<T> ExecuteAsync<T>(Func<Task<T>> action, CancellationToken cancellationToken = default)
+        {
+            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+            try
+            {
+                var result = await action();
+                scope.Complete();
+                return result;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Transaction failed");
+                throw;
+            }
+        }
+
+        public async Task ExecuteAsync(Func<Task> action, CancellationToken cancellationToken = default)
+        {
+            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+            try
+            {
+                await action();
+                scope.Complete();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Transaction failed");
+                throw;
+            }
+        }
+    }
+}
+

--- a/BackendCConecta/BackendCConecta/Program.cs
+++ b/BackendCConecta/BackendCConecta/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Extensions.Options;
 
+using BackendCConecta.Aplicacion.Comportamientos;
 using BackendCConecta.Aplicacion.InterfacesGenerales;// o donde esté IUsuarioService
 using BackendCConecta.Infraestructura.Servicios;// o donde esté UsuarioService
 
@@ -136,6 +137,8 @@ builder.Services.AddScoped<IDatosEmpresaRepository, DatosEmpresaRepository>();
 builder.Services.AddScoped<IDatosEmpresaQueryService, DatosEmpresaQueryService>();
 builder.Services.AddScoped<ICampaniaCommandService, CampaniaService>();
 builder.Services.AddScoped<ICampaniaQueryService, CampaniaService>();
+builder.Services.AddScoped<ITransactionService, TransactionService>();
+builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(TransactionBehavior<,>));
 // 🗂️ FluentValidation
 builder.Services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
 


### PR DESCRIPTION
## Summary
- add `TransactionService` to manage transaction scopes
- use MediatR pipeline behavior to wrap commands in transactions
- log transactional requests with contextual information

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68954f2830fc832ebb6aed88271a8d0f