### PR TITLE
Refactor campaign creation with AutoMapper and validation

### DIFF
--- a/BackendCConecta/BackendCConecta.Tests/CampaniaServiceTests.cs
+++ b/BackendCConecta/BackendCConecta.Tests/CampaniaServiceTests.cs
@@ -1,5 +1,7 @@
+using AutoMapper;
 using BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
 using BackendCConecta.Aplicacion.Modulos.Campanias.Services;
+using BackendCConecta.Aplicacion.Modulos.Campanias.Profiles;
 using BackendCConecta.Dominio.Entidades.Campanias;
 using BackendCConecta.Infraestructura.Persistencia;
 using Microsoft.EntityFrameworkCore;
@@ -39,7 +41,9 @@ public class CampaniaServiceTests
         });
         await context.SaveChangesAsync();
 
-        var service = new CampaniaService(context);
+        var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<CampaniaProfile>());
+        var mapper = mapperConfig.CreateMapper();
+        var service = new CampaniaService(context, mapper);
 
         var result = await service.ObtenerCampaniasAsync();
 

--- a/BackendCConecta/BackendCConecta.Tests/CrearCampaniaHandlerTests.cs
+++ b/BackendCConecta/BackendCConecta.Tests/CrearCampaniaHandlerTests.cs
@@ -1,7 +1,9 @@
+using AutoMapper;
 using BackendCConecta.Aplicacion.Modulos.Campanias.Comandos;
 using BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
 using BackendCConecta.Aplicacion.Modulos.Campanias.Handlers;
 using BackendCConecta.Aplicacion.Modulos.Campanias.Interfaces;
+using BackendCConecta.Aplicacion.Modulos.Campanias.Profiles;
 using Moq;
 using Xunit;
 
@@ -15,7 +17,10 @@ public class CrearCampaniaHandlerTests
         var service = new Mock<ICampaniaCommandService>();
         service.Setup(s => s.CrearCampaniaAsync(It.IsAny<CampaniaDTO>())).ReturnsAsync(1);
 
-        var handler = new CrearCampaniaHandler(service.Object);
+        var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<CampaniaProfile>());
+        var mapper = mapperConfig.CreateMapper();
+
+        var handler = new CrearCampaniaHandler(service.Object, mapper);
         var command = new CrearCampaniaCommand
         {
             Titulo = "Prueba",

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Handlers/CrearCampaniaHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Handlers/CrearCampaniaHandler.cs
@@ -1,3 +1,4 @@
+using AutoMapper;
 using BackendCConecta.Aplicacion.Modulos.Campanias.Comandos;
 using BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
 using BackendCConecta.Aplicacion.Modulos.Campanias.Interfaces;
@@ -11,27 +12,18 @@ namespace BackendCConecta.Aplicacion.Modulos.Campanias.Handlers;
 public class CrearCampaniaHandler : IRequestHandler<CrearCampaniaCommand, int>
 {
     private readonly ICampaniaCommandService _campaniaCommandService;
+    private readonly IMapper _mapper;
 
-    public CrearCampaniaHandler(ICampaniaCommandService campaniaCommandService)
+    public CrearCampaniaHandler(ICampaniaCommandService campaniaCommandService, IMapper mapper)
     {
         _campaniaCommandService = campaniaCommandService;
+        _mapper = mapper;
     }
 
     /// <inheritdoc />
     public Task<int> Handle(CrearCampaniaCommand request, CancellationToken cancellationToken)
     {
-        var dto = new CampaniaDTO
-        {
-            Titulo = request.Titulo,
-            Descripcion = request.Descripcion,
-            TipoCampania = request.TipoCampania,
-            FechaInicio = request.FechaInicio,
-            FechaFin = request.FechaFin,
-            Estado = request.Estado,
-            IdUbicacion = request.IdUbicacion,
-            IdStaff = request.IdStaff
-        };
-
+        var dto = _mapper.Map<CampaniaDTO>(request);
         return _campaniaCommandService.CrearCampaniaAsync(dto);
     }
 }

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Profiles/CampaniaProfile.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Profiles/CampaniaProfile.cs
@@ -1,0 +1,18 @@
+using AutoMapper;
+using BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
+using BackendCConecta.Aplicacion.Modulos.Campanias.Comandos;
+using BackendCConecta.Dominio.Entidades.Campanias;
+
+namespace BackendCConecta.Aplicacion.Modulos.Campanias.Profiles;
+
+public class CampaniaProfile : Profile
+{
+    public CampaniaProfile()
+    {
+        CreateMap<CrearCampaniaCommand, CampaniaDTO>();
+        CreateMap<CampaniaDTO, Campania>()
+            .ForMember(dest => dest.IdCampania, opt => opt.Ignore())
+            .ForMember(dest => dest.FechaRegistro, opt => opt.Ignore());
+        CreateMap<Campania, CampaniaDTO>();
+    }
+}

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Services/CampaniaService.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Services/CampaniaService.cs
@@ -1,3 +1,4 @@
+using AutoMapper;
 using BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
 using BackendCConecta.Aplicacion.Modulos.Campanias.Interfaces;
 using BackendCConecta.Dominio.Entidades.Campanias;
@@ -12,27 +13,19 @@ namespace BackendCConecta.Aplicacion.Modulos.Campanias.Services;
 public class CampaniaService : ICampaniaCommandService, ICampaniaQueryService
 {
     private readonly AppDbContext _context;
+    private readonly IMapper _mapper;
 
-    public CampaniaService(AppDbContext context)
+    public CampaniaService(AppDbContext context, IMapper mapper)
     {
         _context = context;
+        _mapper = mapper;
     }
 
     /// <inheritdoc />
     public async Task<int> CrearCampaniaAsync(CampaniaDTO campania)
     {
-        var entity = new Campania
-        {
-            Titulo = campania.Titulo,
-            Descripcion = campania.Descripcion,
-            TipoCampania = campania.TipoCampania,
-            FechaInicio = campania.FechaInicio,
-            FechaFin = campania.FechaFin,
-            Estado = campania.Estado,
-            IdUbicacion = campania.IdUbicacion,
-            IdStaff = campania.IdStaff,
-            FechaRegistro = DateTime.UtcNow
-        };
+        var entity = _mapper.Map<Campania>(campania);
+        entity.FechaRegistro = DateTime.UtcNow;
 
         _context.Campanias.Add(entity);
         await _context.SaveChangesAsync();
@@ -43,20 +36,8 @@ public class CampaniaService : ICampaniaCommandService, ICampaniaQueryService
     /// <inheritdoc />
     public async Task<IReadOnlyList<CampaniaDTO>> ObtenerCampaniasAsync()
     {
-        return await _context.Campanias
-            .Select(c => new CampaniaDTO
-            {
-                IdCampania = c.IdCampania,
-                Titulo = c.Titulo,
-                Descripcion = c.Descripcion,
-                TipoCampania = c.TipoCampania,
-                FechaInicio = c.FechaInicio,
-                FechaFin = c.FechaFin,
-                Estado = c.Estado,
-                IdUbicacion = c.IdUbicacion,
-                IdStaff = c.IdStaff
-            })
-            .ToListAsync();
+        var entities = await _context.Campanias.ToListAsync();
+        return _mapper.Map<List<CampaniaDTO>>(entities);
     }
 }
 

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Validadores/CrearCampaniaValidator.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Validadores/CrearCampaniaValidator.cs
@@ -7,6 +7,21 @@ public class CrearCampaniaValidator : AbstractValidator<CrearCampaniaCommand>
 {
     public CrearCampaniaValidator()
     {
-        // No rules defined yet.
+        RuleFor(x => x.Titulo)
+            .NotEmpty();
+
+        RuleFor(x => x.TipoCampania)
+            .NotEmpty();
+
+        RuleFor(x => x.FechaInicio)
+            .NotEmpty()
+            .LessThan(x => x.FechaFin);
+
+        RuleFor(x => x.FechaFin)
+            .NotEmpty()
+            .GreaterThan(x => x.FechaInicio);
+
+        RuleFor(x => x.IdStaff)
+            .GreaterThan(0);
     }
 }


### PR DESCRIPTION
## Summary
- Refactor campaign creation handler to use AutoMapper and delegate mapping
- Introduce FluentValidation rules and AutoMapper profiles for campaigns
- Update campaign service and tests to leverage AutoMapper

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6895506b3cc4832e86eec4dcb8613771