### PR TITLE
feat: add paquetes module skeleton

### DIFF
--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Comandos/ActualizarPaquetesCommand.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Comandos/ActualizarPaquetesCommand.cs
@@ -1,0 +1,12 @@
+using MediatR;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.DTOs;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.Comandos
+{
+    public class ActualizarPaquetesCommand : IRequest<PaquetesDto>
+    {
+        public int Id { get; set; }
+        public string Nombre { get; set; } = null!;
+        public string Estado { get; set; } = null!;
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Comandos/CambiarEstadoPaquetesCommand.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Comandos/CambiarEstadoPaquetesCommand.cs
@@ -1,0 +1,10 @@
+using MediatR;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.Comandos
+{
+    public class CambiarEstadoPaquetesCommand : IRequest<bool>
+    {
+        public int Id { get; set; }
+        public string Estado { get; set; } = null!;
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Comandos/CrearPaquetesCommand.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Comandos/CrearPaquetesCommand.cs
@@ -1,0 +1,13 @@
+using MediatR;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.DTOs;
+using System;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.Comandos
+{
+    public class CrearPaquetesCommand : IRequest<PaquetesDto>
+    {
+        public string Nombre { get; set; } = null!;
+        public string Estado { get; set; } = null!;
+        public DateTime FechaCreacion { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Comandos/EliminarPaquetesCommand.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Comandos/EliminarPaquetesCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.Comandos
+{
+    public class EliminarPaquetesCommand : IRequest<bool>
+    {
+        public int Id { get; set; }
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/DTOs/ActualizarPaquetesDto.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/DTOs/ActualizarPaquetesDto.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.DTOs
+{
+    public record ActualizarPaquetesDto(int Id, string Nombre, string Estado, DateTime FechaCreacion);
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/DTOs/CrearPaquetesDto.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/DTOs/CrearPaquetesDto.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.DTOs
+{
+    public record CrearPaquetesDto(int Id, string Nombre, string Estado, DateTime FechaCreacion);
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/DTOs/PaquetesDto.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/DTOs/PaquetesDto.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.DTOs
+{
+    public record PaquetesDto(int Id, string Nombre, string Estado, DateTime FechaCreacion);
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Handlers/ActualizarPaquetesHandler.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Handlers/ActualizarPaquetesHandler.cs
@@ -1,0 +1,24 @@
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.DTOs;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.Interfaces;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.Handlers
+{
+    public class ActualizarPaquetesHandler : IRequestHandler<ActualizarPaquetesCommand, PaquetesDto>
+    {
+        private readonly IPaquetesService _paquetesService;
+
+        public ActualizarPaquetesHandler(IPaquetesService paquetesService)
+        {
+            _paquetesService = paquetesService;
+        }
+
+        public async Task<PaquetesDto> Handle(ActualizarPaquetesCommand request, CancellationToken cancellationToken)
+        {
+            return await _paquetesService.ActualizarPaqueteAsync(request);
+        }
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Handlers/CambiarEstadoPaquetesHandler.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Handlers/CambiarEstadoPaquetesHandler.cs
@@ -1,0 +1,23 @@
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.Interfaces;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.Handlers
+{
+    public class CambiarEstadoPaquetesHandler : IRequestHandler<CambiarEstadoPaquetesCommand, bool>
+    {
+        private readonly IPaquetesService _paquetesService;
+
+        public CambiarEstadoPaquetesHandler(IPaquetesService paquetesService)
+        {
+            _paquetesService = paquetesService;
+        }
+
+        public async Task<bool> Handle(CambiarEstadoPaquetesCommand request, CancellationToken cancellationToken)
+        {
+            return await _paquetesService.CambiarEstadoPaqueteAsync(request);
+        }
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Handlers/CrearPaquetesHandler.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Handlers/CrearPaquetesHandler.cs
@@ -1,0 +1,24 @@
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.DTOs;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.Interfaces;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.Handlers
+{
+    public class CrearPaquetesHandler : IRequestHandler<CrearPaquetesCommand, PaquetesDto>
+    {
+        private readonly IPaquetesService _paquetesService;
+
+        public CrearPaquetesHandler(IPaquetesService paquetesService)
+        {
+            _paquetesService = paquetesService;
+        }
+
+        public async Task<PaquetesDto> Handle(CrearPaquetesCommand request, CancellationToken cancellationToken)
+        {
+            return await _paquetesService.CrearPaqueteAsync(request);
+        }
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Handlers/EliminarPaquetesHandler.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Handlers/EliminarPaquetesHandler.cs
@@ -1,0 +1,23 @@
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.Interfaces;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.Handlers
+{
+    public class EliminarPaquetesHandler : IRequestHandler<EliminarPaquetesCommand, bool>
+    {
+        private readonly IPaquetesService _paquetesService;
+
+        public EliminarPaquetesHandler(IPaquetesService paquetesService)
+        {
+            _paquetesService = paquetesService;
+        }
+
+        public async Task<bool> Handle(EliminarPaquetesCommand request, CancellationToken cancellationToken)
+        {
+            return await _paquetesService.EliminarPaqueteAsync(request.Id);
+        }
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Interfaces/IPaquetesService.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Interfaces/IPaquetesService.cs
@@ -1,0 +1,14 @@
+using BackendCConecta.Aplicacion.Modulos.Paquetes.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.DTOs;
+using System.Threading.Tasks;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.Interfaces
+{
+    public interface IPaquetesService
+    {
+        Task<PaquetesDto> CrearPaqueteAsync(CrearPaquetesCommand request);
+        Task<PaquetesDto> ActualizarPaqueteAsync(ActualizarPaquetesCommand request);
+        Task<bool> EliminarPaqueteAsync(int id);
+        Task<bool> CambiarEstadoPaqueteAsync(CambiarEstadoPaquetesCommand request);
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Servicios/PaquetesService.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Servicios/PaquetesService.cs
@@ -1,0 +1,31 @@
+using BackendCConecta.Aplicacion.Modulos.Paquetes.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.DTOs;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.Interfaces;
+using System;
+using System.Threading.Tasks;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.Servicios
+{
+    public class PaquetesService : IPaquetesService
+    {
+        public Task<PaquetesDto> CrearPaqueteAsync(CrearPaquetesCommand request)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<PaquetesDto> ActualizarPaqueteAsync(ActualizarPaquetesCommand request)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<bool> EliminarPaqueteAsync(int id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<bool> CambiarEstadoPaqueteAsync(CambiarEstadoPaquetesCommand request)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Validadores/ActualizarPaquetesValidator.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Validadores/ActualizarPaquetesValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.Comandos;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.Validadores
+{
+    public class ActualizarPaquetesValidator : AbstractValidator<ActualizarPaquetesCommand>
+    {
+        public ActualizarPaquetesValidator()
+        {
+            RuleFor(x => x.Id).GreaterThan(0).WithMessage("El ID debe ser mayor que cero.");
+            RuleFor(x => x.Nombre).NotEmpty().WithMessage("El nombre es obligatorio.");
+            RuleFor(x => x.Estado).NotEmpty().WithMessage("El estado es obligatorio.");
+        }
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Validadores/CambiarEstadoPaquetesValidator.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Validadores/CambiarEstadoPaquetesValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.Comandos;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.Validadores
+{
+    public class CambiarEstadoPaquetesValidator : AbstractValidator<CambiarEstadoPaquetesCommand>
+    {
+        public CambiarEstadoPaquetesValidator()
+        {
+            RuleFor(x => x.Id).GreaterThan(0).WithMessage("El ID debe ser mayor que cero.");
+            RuleFor(x => x.Estado).NotEmpty().WithMessage("El estado es obligatorio.");
+        }
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Validadores/CrearPaquetesValidator.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Validadores/CrearPaquetesValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.Comandos;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.Validadores
+{
+    public class CrearPaquetesValidator : AbstractValidator<CrearPaquetesCommand>
+    {
+        public CrearPaquetesValidator()
+        {
+            RuleFor(x => x.Nombre).NotEmpty().WithMessage("El nombre es obligatorio.");
+            RuleFor(x => x.Estado).NotEmpty().WithMessage("El estado es obligatorio.");
+        }
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Validadores/EliminarPaquetesValidator.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Paquetes/Validadores/EliminarPaquetesValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using BackendCConecta.Aplicacion.Modulos.Paquetes.Comandos;
+
+namespace BackendCConecta.Aplicacion.Modulos.Paquetes.Validadores
+{
+    public class EliminarPaquetesValidator : AbstractValidator<EliminarPaquetesCommand>
+    {
+        public EliminarPaquetesValidator()
+        {
+            RuleFor(x => x.Id).GreaterThan(0).WithMessage("El ID debe ser mayor que cero.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Paquetes module structure with DTOs, commands, handlers, validators, and service interface/stub

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68955e4f147c832e9ced4db1a5799d3b