### PR TITLE
Add Staff module skeleton with DTOs, commands, handlers and validators

### DIFF
--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Comandos/ActualizarStaffCommand.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Comandos/ActualizarStaffCommand.cs
@@ -1,0 +1,14 @@
+using MediatR;
+using BackendCConecta.Aplicacion.Modulos.Staff.DTOs;
+using System;
+
+namespace BackendCConecta.Aplicacion.Modulos.Staff.Comandos
+{
+    public class ActualizarStaffCommand : IRequest<StaffDto>
+    {
+        public int Id { get; set; }
+        public string Nombre { get; set; } = null!;
+        public string Estado { get; set; } = null!;
+        public DateTime FechaCreacion { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Comandos/CrearStaffCommand.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Comandos/CrearStaffCommand.cs
@@ -1,0 +1,13 @@
+using MediatR;
+using BackendCConecta.Aplicacion.Modulos.Staff.DTOs;
+using System;
+
+namespace BackendCConecta.Aplicacion.Modulos.Staff.Comandos
+{
+    public class CrearStaffCommand : IRequest<StaffDto>
+    {
+        public string Nombre { get; set; } = null!;
+        public string Estado { get; set; } = null!;
+        public DateTime FechaCreacion { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Comandos/EliminarStaffCommand.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Comandos/EliminarStaffCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace BackendCConecta.Aplicacion.Modulos.Staff.Comandos
+{
+    public class EliminarStaffCommand : IRequest<bool>
+    {
+        public int Id { get; set; }
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/DTOs/ActualizarStaffDto.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/DTOs/ActualizarStaffDto.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace BackendCConecta.Aplicacion.Modulos.Staff.DTOs
+{
+    public record ActualizarStaffDto(int Id, string Nombre, string Estado, DateTime FechaCreacion);
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/DTOs/CrearStaffDto.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/DTOs/CrearStaffDto.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace BackendCConecta.Aplicacion.Modulos.Staff.DTOs
+{
+    public record CrearStaffDto(int Id, string Nombre, string Estado, DateTime FechaCreacion);
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/DTOs/StaffDto.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/DTOs/StaffDto.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace BackendCConecta.Aplicacion.Modulos.Staff.DTOs
+{
+    public record StaffDto(int Id, string Nombre, string Estado, DateTime FechaCreacion);
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Handlers/ActualizarStaffHandler.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Handlers/ActualizarStaffHandler.cs
@@ -1,0 +1,24 @@
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+using BackendCConecta.Aplicacion.Modulos.Staff.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Staff.DTOs;
+using BackendCConecta.Aplicacion.Modulos.Staff.Interfaces;
+
+namespace BackendCConecta.Aplicacion.Modulos.Staff.Handlers
+{
+    public class ActualizarStaffHandler : IRequestHandler<ActualizarStaffCommand, StaffDto>
+    {
+        private readonly IStaffService _staffService;
+
+        public ActualizarStaffHandler(IStaffService staffService)
+        {
+            _staffService = staffService;
+        }
+
+        public async Task<StaffDto> Handle(ActualizarStaffCommand request, CancellationToken cancellationToken)
+        {
+            return await _staffService.ActualizarStaffAsync(request);
+        }
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Handlers/CrearStaffHandler.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Handlers/CrearStaffHandler.cs
@@ -1,0 +1,24 @@
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+using BackendCConecta.Aplicacion.Modulos.Staff.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Staff.DTOs;
+using BackendCConecta.Aplicacion.Modulos.Staff.Interfaces;
+
+namespace BackendCConecta.Aplicacion.Modulos.Staff.Handlers
+{
+    public class CrearStaffHandler : IRequestHandler<CrearStaffCommand, StaffDto>
+    {
+        private readonly IStaffService _staffService;
+
+        public CrearStaffHandler(IStaffService staffService)
+        {
+            _staffService = staffService;
+        }
+
+        public async Task<StaffDto> Handle(CrearStaffCommand request, CancellationToken cancellationToken)
+        {
+            return await _staffService.CrearStaffAsync(request);
+        }
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Handlers/EliminarStaffHandler.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Handlers/EliminarStaffHandler.cs
@@ -1,0 +1,23 @@
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+using BackendCConecta.Aplicacion.Modulos.Staff.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Staff.Interfaces;
+
+namespace BackendCConecta.Aplicacion.Modulos.Staff.Handlers
+{
+    public class EliminarStaffHandler : IRequestHandler<EliminarStaffCommand, bool>
+    {
+        private readonly IStaffService _staffService;
+
+        public EliminarStaffHandler(IStaffService staffService)
+        {
+            _staffService = staffService;
+        }
+
+        public async Task<bool> Handle(EliminarStaffCommand request, CancellationToken cancellationToken)
+        {
+            return await _staffService.EliminarStaffAsync(request.Id);
+        }
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Interfaces/IStaffService.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Interfaces/IStaffService.cs
@@ -1,0 +1,13 @@
+using BackendCConecta.Aplicacion.Modulos.Staff.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Staff.DTOs;
+using System.Threading.Tasks;
+
+namespace BackendCConecta.Aplicacion.Modulos.Staff.Interfaces
+{
+    public interface IStaffService
+    {
+        Task<StaffDto> CrearStaffAsync(CrearStaffCommand request);
+        Task<StaffDto> ActualizarStaffAsync(ActualizarStaffCommand request);
+        Task<bool> EliminarStaffAsync(int id);
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Servicios/StaffService.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Servicios/StaffService.cs
@@ -1,0 +1,26 @@
+using BackendCConecta.Aplicacion.Modulos.Staff.Comandos;
+using BackendCConecta.Aplicacion.Modulos.Staff.DTOs;
+using BackendCConecta.Aplicacion.Modulos.Staff.Interfaces;
+using System;
+using System.Threading.Tasks;
+
+namespace BackendCConecta.Aplicacion.Modulos.Staff.Servicios
+{
+    public class StaffService : IStaffService
+    {
+        public Task<StaffDto> CrearStaffAsync(CrearStaffCommand request)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<StaffDto> ActualizarStaffAsync(ActualizarStaffCommand request)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<bool> EliminarStaffAsync(int id)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Validadores/ActualizarStaffValidator.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Validadores/ActualizarStaffValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using BackendCConecta.Aplicacion.Modulos.Staff.Comandos;
+
+namespace BackendCConecta.Aplicacion.Modulos.Staff.Validadores
+{
+    public class ActualizarStaffValidator : AbstractValidator<ActualizarStaffCommand>
+    {
+        public ActualizarStaffValidator()
+        {
+            RuleFor(x => x.Id).GreaterThan(0).WithMessage("El id es obligatorio.");
+            RuleFor(x => x.Nombre).NotEmpty().WithMessage("El nombre es obligatorio.");
+            RuleFor(x => x.Estado).NotEmpty().WithMessage("El estado es obligatorio.");
+        }
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Validadores/CrearStaffValidator.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Validadores/CrearStaffValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using BackendCConecta.Aplicacion.Modulos.Staff.Comandos;
+
+namespace BackendCConecta.Aplicacion.Modulos.Staff.Validadores
+{
+    public class CrearStaffValidator : AbstractValidator<CrearStaffCommand>
+    {
+        public CrearStaffValidator()
+        {
+            RuleFor(x => x.Nombre).NotEmpty().WithMessage("El nombre es obligatorio.");
+            RuleFor(x => x.Estado).NotEmpty().WithMessage("El estado es obligatorio.");
+        }
+    }
+}

--- a/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Validadores/EliminarStaffValidator.cs
+++ b/BackendCConecta/src/BackendCConecta.Aplicacion/Modulos/Staff/Validadores/EliminarStaffValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using BackendCConecta.Aplicacion.Modulos.Staff.Comandos;
+
+namespace BackendCConecta.Aplicacion.Modulos.Staff.Validadores
+{
+    public class EliminarStaffValidator : AbstractValidator<EliminarStaffCommand>
+    {
+        public EliminarStaffValidator()
+        {
+            RuleFor(x => x.Id).GreaterThan(0).WithMessage("El id es obligatorio.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- set up Staff module scaffolding with DTOs for creation and update
- add commands and handlers that delegate to IStaffService
- stub out IStaffService and StaffService implementations
- include FluentValidation validators for staff commands

## Testing
- `dotnet test BackendCConecta/BackendCConecta.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68955f4b9cb0832e804a64a4bacebdaa