### PR TITLE
Fix NuGet packages and startup for ASP.NET Core 8

### DIFF
--- a/BackendCConecta/BackendCConecta/BackendCConecta.csproj
+++ b/BackendCConecta/BackendCConecta/BackendCConecta.csproj
@@ -6,9 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="11.9.0" />
-    <PackageReference Include="MediatR" Version="12.2.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="12.2.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
+    <PackageReference Include="FluentValidation" Version="11.9.0" />
+    <PackageReference Include="MediatR" Version="11.1.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.19" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.17" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.17" />

--- a/BackendCConecta/BackendCConecta/Program.cs
+++ b/BackendCConecta/BackendCConecta/Program.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using System.Security.Claims;
 using FluentValidation;
+using FluentValidation.AspNetCore;
 using MediatR;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
@@ -145,10 +146,13 @@ builder.Services.AddScoped<IFechasImportantesService, FechasImportantesService>(
 builder.Services.AddScoped<ITransactionService, TransactionService>();
 builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(TransactionBehavior<,>));
 // 🗂️ FluentValidation
-builder.Services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
+builder.Services
+    .AddControllers()
+    .AddFluentValidation();
+builder.Services.AddValidatorsFromAssemblyContaining<Program>();
 
 // 🧠 MediatR
-builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
+builder.Services.AddMediatR(typeof(Program));
 builder.Services.AddAutoMapper(Assembly.GetExecutingAssembly());
 
 // ---------------------------------------------
@@ -164,7 +168,6 @@ builder.Services.AddAuthorization(options =>
 // ---------------------------------------------
 // 🚀 Otros servicios esenciales
 // ---------------------------------------------
-builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 


### PR DESCRIPTION
## Summary
- pin FluentValidation and MediatR packages to stable 11.x versions available in the environment
- update Program.cs to use MediatR 11 registration and FluentValidation MVC integration

## Testing
- `apt-get install -y dotnet-sdk-8.0` *(fails: repository forbidden)*
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68968144b20c832e8bb6a531be33b5d4