### PR TITLE
chore: align FluentValidation packages

### DIFF
--- a/BackendCConecta/BackendCConecta/BackendCConecta.csproj
+++ b/BackendCConecta/BackendCConecta/BackendCConecta.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
-    <PackageReference Include="FluentValidation" Version="11.9.0" />
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="MediatR" Version="11.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.19" />

--- a/README_FIX.md
+++ b/README_FIX.md
@@ -1,31 +1,21 @@
 # BackendCConecta Build Notes
 
 ## Dependencias
-- AutoMapper.Extensions.Microsoft.DependencyInjection 12.0.1
-- FluentValidation.AspNetCore 11.9.0
-- MediatR 12.2.0
-- MediatR.Extensions.Microsoft.DependencyInjection 12.2.0
-- Microsoft.AspNetCore.Authentication.JwtBearer 8.0.19
-- Microsoft.AspNetCore.OpenApi 8.0.17
-- Microsoft.EntityFrameworkCore 8.0.17
-- Microsoft.EntityFrameworkCore.Design 8.0.17
-- Microsoft.EntityFrameworkCore.SqlServer 8.0.17
-- Microsoft.EntityFrameworkCore.Tools 8.0.17
-- Microsoft.Extensions.Options.ConfigurationExtensions 8.0.0
-- Swashbuckle.AspNetCore 6.6.2
-- System.IdentityModel.Tokens.Jwt 8.13.0
+
+| Paquete | Antes | Después |
+| --- | --- | --- |
+| FluentValidation | 11.9.0 | 11.11.0 |
+| FluentValidation.AspNetCore | 11.3.1 | 11.3.1 |
+
+El resto de dependencias (AutoMapper, MediatR, Microsoft.* 8.x, etc.) permanecen sin cambios.
 
 ## Feeds NuGet
-- Unica fuente: `https://api.nuget.org/v3/index.json`
+- Única fuente: `https://api.nuget.org/v3/index.json`
 - Fuentes locales de Visual Studio deshabilitadas
 
 ## Comandos
 ```bash
 dotnet restore --no-cache
-dotnet clean
 dotnet build -c Debug -v minimal
+dotnet run --launch-profile https
 ```
-
-### Ejecución
-Perfil HTTPS configurado en `Properties/launchSettings.json`.
-Ejecutar con `dotnet run --launch-profile https` o F5 desde el IDE.


### PR DESCRIPTION
## Summary
- bump FluentValidation to 11.11.0 to satisfy FluentValidation.AspNetCore requirements
- document updated NuGet feed and build commands

## Testing
- `dotnet restore --no-cache` *(fails: command not found)*
- `dotnet build -c Debug -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689687aa1a9c832eb7d608158a57f136