### PR TITLE
fix: update MediatR registration and package versions

### DIFF
--- a/BackendCConecta/BackendCConecta/BackendCConecta.csproj
+++ b/BackendCConecta/BackendCConecta/BackendCConecta.csproj
@@ -8,10 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="11.8.1" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />
-    <PackageReference Include="MediatR" Version="12.1.1" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="12.1.1" />
+    <PackageReference Include="MediatR" Version="12.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.19" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.17" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.17" />

--- a/BackendCConecta/BackendCConecta/Program.cs
+++ b/BackendCConecta/BackendCConecta/Program.cs
@@ -152,7 +152,10 @@ builder.Services
 builder.Services.AddValidatorsFromAssemblyContaining<Program>();
 
 // 🧠 MediatR
-builder.Services.AddMediatR(typeof(Program));
+builder.Services.AddMediatR(cfg =>
+{
+    cfg.RegisterServicesFromAssembly(typeof(Program).Assembly);
+});
 builder.Services.AddAutoMapper(Assembly.GetExecutingAssembly());
 
 // ---------------------------------------------


### PR DESCRIPTION
## Summary
- replace MediatR.Extensions package usage with built-in MediatR registration
- pin FluentValidation.AspNetCore to 11.3.1 and update MediatR to 12.2.0

## Testing
- `dotnet restore BackendCConecta.sln --no-cache` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68969c4901e4832eb50e4d67297320d2