### PR TITLE
Fix namespaces and MediatR signatures

### DIFF
--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Comandos/RegistrarParticipanteCommand.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Comandos/RegistrarParticipanteCommand.cs
@@ -1,6 +1,6 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Campañas.Comandos
+namespace BackendCConecta.Aplicacion.Modulos.Campanias.Comandos;
+
+public class RegistrarParticipanteCommand
 {
-    public class RegistrarParticipanteCommand
-    {
-    }
 }
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Consultas/ObtenerParticipantesQuery.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Consultas/ObtenerParticipantesQuery.cs
@@ -1,6 +1,6 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Campañas.Consultas
+namespace BackendCConecta.Aplicacion.Modulos.Campanias.Consultas;
+
+public class ObtenerParticipantesQuery
 {
-    public class ObtenerParticipantesQuery
-    {
-    }
 }
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/DTOs/ParticipanteDTO.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/DTOs/ParticipanteDTO.cs
@@ -1,6 +1,6 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Campañas.DTOs
+namespace BackendCConecta.Aplicacion.Modulos.Campanias.DTOs;
+
+public class ParticipanteDTO
 {
-    public class ParticipanteDTO
-    {
-    }
 }
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Handlers/RegistrarParticipanteHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Handlers/RegistrarParticipanteHandler.cs
@@ -1,6 +1,13 @@
-﻿namespace BackendCConecta.Aplicacion.Modulos.Campañas.Handlers
+using MediatR;
+using BackendCConecta.Aplicacion.Modulos.Campanias.Comandos;
+
+namespace BackendCConecta.Aplicacion.Modulos.Campanias.Handlers;
+
+public class RegistrarParticipanteHandler : IRequestHandler<RegistrarParticipanteCommand, Unit>
 {
-    public class RegistrarParticipanteHandler
+    public Task<Unit> Handle(RegistrarParticipanteCommand request, CancellationToken cancellationToken)
     {
+        return Task.FromResult(Unit.Value);
     }
 }
+

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Validadores/RegistrarParticipanteValidator.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Campanias/Validadores/RegistrarParticipanteValidator.cs
@@ -7,6 +7,5 @@ public class RegistrarParticipanteValidator : AbstractValidator<RegistrarPartici
 {
     public RegistrarParticipanteValidator()
     {
-        // No rules defined yet.
     }
 }

--- a/BackendCConecta/BackendCConecta/Dominio/Entidades/Colaboradores/PerfilColaboradorExtendido.cs
+++ b/BackendCConecta/BackendCConecta/Dominio/Entidades/Colaboradores/PerfilColaboradorExtendido.cs
@@ -17,5 +17,5 @@ public partial class PerfilColaboradorExtendido
 
     public string? MensajePromocional { get; set; }
 
-    public virtual Colaboradore IdColaboradorNavigation { get; set; } = null!;
+    public virtual Colaborador IdColaboradorNavigation { get; set; } = null!;
 }

--- a/BackendCConecta/BackendCConecta/Dominio/Entidades/Representantes/MeGustaRepresentante.cs
+++ b/BackendCConecta/BackendCConecta/Dominio/Entidades/Representantes/MeGustaRepresentante.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using BackendCConecta.Dominio.Entidades.Usuario;
+using BackendCConecta.Dominio.Entidades.Usuarios;
 
 namespace BackendCConecta.Dominio.Entidades.Representantes;
 

--- a/BackendCConecta/BackendCConecta/Infraestructura/Persistencia/AppDbContext.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Persistencia/AppDbContext.cs
@@ -573,7 +573,7 @@ public partial class AppDbContext : DbContext
                 .HasColumnType("text")
                 .HasColumnName("observaciones");
 
-            entity.HasOne(d => d.IdDatosUsuarioNavigation).WithOne(p => p.Colaboradore)
+            entity.HasOne(d => d.IdDatosUsuarioNavigation).WithOne(p => p.Colaborador)
                 .HasForeignKey<Colaborador>(d => d.IdDatosUsuario)
                 .OnDelete(DeleteBehavior.ClientSetNull)
                 .HasConstraintName("FK__Colaborad__id_da__48EFCE0F");

--- a/BackendCConecta/BackendCConecta/Infraestructura/Persistencia/Configuration/Publicaciones/AvisoConfiguration.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Persistencia/Configuration/Publicaciones/AvisoConfiguration.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore;
-using BackendCConecta.Dominio.Entidades.Publicaciones;
-
-namespace BackendCConecta.Infraestructura.Persistencia.Configuraciones.Publicaciones
+using BackendCConecta.Dominio.Entidades.Avisos;
+ 
+namespace BackendCConecta.Infraestructura.Persistencia.Configuration.Publicaciones
 {
     public class AvisoConfiguration : IEntityTypeConfiguration<Aviso>
     {

--- a/BackendCConecta/BackendCConecta/Infraestructura/Persistencia/Configuration/Usuarios/DatosEmpresaConfiguration.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Persistencia/Configuration/Usuarios/DatosEmpresaConfiguration.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore;
-using BackendCConecta.Dominio.Entidades.Usuarios;
+using BackendCConecta.Dominio.Entidades.Empresas;
 
-namespace BackendCConecta.Infraestructura.Persistencia.Configuraciones.Usuarios
+namespace BackendCConecta.Infraestructura.Persistencia.Configuration.Usuarios
 {
 
 


### PR DESCRIPTION
## Summary
- align entity namespaces for Usuario, Aviso, DatosEmpresa
- correct MediatR handler patterns and campanias module namespaces
- fix Colaborador references and navigation property

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896a13d22a0832e9254d84d52246f94