### PR TITLE
Add optional CancellationToken support in repositories

### DIFF
--- a/BackendCConecta/BackendCConecta/Aplicacion/InterfacesGenerales/IRepositorioGenerico.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/InterfacesGenerales/IRepositorioGenerico.cs
@@ -1,4 +1,6 @@
 using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace BackendCConecta.Aplicacion.InterfacesGenerales;
 
@@ -12,34 +14,34 @@ public interface IRepositorioGenerico<T> where T : class
     /// Obtiene una entidad por su identificador primario.
     /// </summary>
     /// <param name="id">Identificador de la entidad.</param>
-    Task<T?> ObtenerPorIdAsync(int id);
+    Task<T?> ObtenerPorIdAsync(int id, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Obtiene todas las entidades del tipo especificado.
     /// </summary>
-    Task<IEnumerable<T>> ObtenerTodosAsync();
+    Task<IEnumerable<T>> ObtenerTodosAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Inserta una nueva entidad en el contexto de datos.
     /// </summary>
     /// <param name="entidad">Entidad a insertar.</param>
-    Task InsertarAsync(T entidad);
+    Task InsertarAsync(T entidad, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Actualiza una entidad existente en el contexto de datos.
     /// </summary>
     /// <param name="entidad">Entidad a actualizar.</param>
-    Task ActualizarAsync(T entidad);
+    Task ActualizarAsync(T entidad, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Elimina una entidad del contexto de datos.
     /// </summary>
     /// <param name="entidad">Entidad a eliminar.</param>
-    Task EliminarAsync(T entidad);
+    Task EliminarAsync(T entidad, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Permite realizar consultas personalizadas sobre la entidad.
     /// </summary>
     /// <param name="predicado">Expresión con la condición de filtro.</param>
-    Task<IEnumerable<T>> BuscarAsync(Expression<Func<T, bool>> predicado);
+    Task<IEnumerable<T>> BuscarAsync(Expression<Func<T, bool>> predicado, CancellationToken cancellationToken = default);
 }

--- a/BackendCConecta/BackendCConecta/Dominio/Repositorios/ILugaresReferenciaRepository.cs
+++ b/BackendCConecta/BackendCConecta/Dominio/Repositorios/ILugaresReferenciaRepository.cs
@@ -1,12 +1,14 @@
 using BackendCConecta.Dominio.Entidades.Ubicaciones;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace BackendCConecta.Dominio.Repositorios;
 
 public interface ILugaresReferenciaRepository
 {
-    Task<LugaresReferencia?> ObtenerPorIdAsync(int id);
-    Task<IEnumerable<LugaresReferencia>> ListarAsync();
-    Task InsertarAsync(LugaresReferencia entidad);
-    Task ActualizarAsync(LugaresReferencia entidad);
-    Task EliminarAsync(LugaresReferencia entidad);
+    Task<LugaresReferencia?> ObtenerPorIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<LugaresReferencia>> ListarAsync(CancellationToken cancellationToken = default);
+    Task InsertarAsync(LugaresReferencia entidad, CancellationToken cancellationToken = default);
+    Task ActualizarAsync(LugaresReferencia entidad, CancellationToken cancellationToken = default);
+    Task EliminarAsync(LugaresReferencia entidad, CancellationToken cancellationToken = default);
 }

--- a/BackendCConecta/BackendCConecta/Dominio/Repositorios/IUbicacionesSistemaRepository.cs
+++ b/BackendCConecta/BackendCConecta/Dominio/Repositorios/IUbicacionesSistemaRepository.cs
@@ -1,13 +1,14 @@
-﻿using BackendCConecta.Dominio.Entidades.Ubicaciones;
+using System.Threading;
+using System.Threading.Tasks;
+using BackendCConecta.Dominio.Entidades.Ubicaciones;
 
-namespace BackendCConecta.Dominio.Repositorios
+namespace BackendCConecta.Dominio.Repositorios;
+
+public interface IUbicacionesSistemaRepository
 {
-    public interface IUbicacionesSistemaRepository
-    {
-        Task<UbicacionSistema?> ObtenerPorIdAsync(int id);
-        Task<IEnumerable<UbicacionSistema>> ListarAsync();
-        Task InsertarAsync(UbicacionSistema entidad);
-        Task ActualizarAsync(UbicacionSistema entidad);
-        Task EliminarAsync(UbicacionSistema entidad);
-    }
+    Task<UbicacionSistema?> ObtenerPorIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<UbicacionSistema>> ListarAsync(CancellationToken cancellationToken = default);
+    Task InsertarAsync(UbicacionSistema entidad, CancellationToken cancellationToken = default);
+    Task ActualizarAsync(UbicacionSistema entidad, CancellationToken cancellationToken = default);
+    Task EliminarAsync(UbicacionSistema entidad, CancellationToken cancellationToken = default);
 }

--- a/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/RepositorioGenerico.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/RepositorioGenerico.cs
@@ -1,4 +1,6 @@
 using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
 using BackendCConecta.Aplicacion.InterfacesGenerales;
 using BackendCConecta.Infraestructura.Persistencia;
 using Microsoft.EntityFrameworkCore;
@@ -9,47 +11,47 @@ namespace BackendCConecta.Infraestructura.Repositorios;
 /// Implementación genérica de operaciones comunes para repositorios.
 /// </summary>
 /// <typeparam name="T">Tipo de la entidad manejada.</typeparam>
-public class RepositorioGenerico<T> : IRepositorioGenerico<T> where T : class
-{
-    protected readonly AppDbContext _context;
-    protected readonly DbSet<T> _dbSet;
-
-    public RepositorioGenerico(AppDbContext context)
+    public class RepositorioGenerico<T> : IRepositorioGenerico<T> where T : class
     {
-        _context = context;
-        _dbSet = _context.Set<T>();
-    }
+        protected readonly AppDbContext _context;
+        protected readonly DbSet<T> _dbSet;
 
-    public virtual async Task<T?> ObtenerPorIdAsync(int id)
-    {
-        return await _dbSet.FindAsync(id);
-    }
+        public RepositorioGenerico(AppDbContext context)
+        {
+            _context = context;
+            _dbSet = _context.Set<T>();
+        }
 
-    public virtual async Task<IEnumerable<T>> ObtenerTodosAsync()
-    {
-        return await _dbSet.ToListAsync();
-    }
+        public virtual async Task<T?> ObtenerPorIdAsync(int id, CancellationToken cancellationToken = default)
+        {
+            return await _dbSet.FindAsync(new object?[] { id }, cancellationToken);
+        }
 
-    public virtual async Task InsertarAsync(T entidad)
-    {
-        await _dbSet.AddAsync(entidad);
-        await _context.SaveChangesAsync();
-    }
+        public virtual async Task<IEnumerable<T>> ObtenerTodosAsync(CancellationToken cancellationToken = default)
+        {
+            return await _dbSet.ToListAsync(cancellationToken);
+        }
 
-    public virtual async Task ActualizarAsync(T entidad)
-    {
-        _dbSet.Update(entidad);
-        await _context.SaveChangesAsync();
-    }
+        public virtual async Task InsertarAsync(T entidad, CancellationToken cancellationToken = default)
+        {
+            await _dbSet.AddAsync(entidad, cancellationToken);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
 
-    public virtual async Task EliminarAsync(T entidad)
-    {
-        _dbSet.Remove(entidad);
-        await _context.SaveChangesAsync();
-    }
+        public virtual async Task ActualizarAsync(T entidad, CancellationToken cancellationToken = default)
+        {
+            _dbSet.Update(entidad);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
 
-    public virtual async Task<IEnumerable<T>> BuscarAsync(Expression<Func<T, bool>> predicado)
-    {
-        return await _dbSet.Where(predicado).ToListAsync();
+        public virtual async Task EliminarAsync(T entidad, CancellationToken cancellationToken = default)
+        {
+            _dbSet.Remove(entidad);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
+        public virtual async Task<IEnumerable<T>> BuscarAsync(Expression<Func<T, bool>> predicado, CancellationToken cancellationToken = default)
+        {
+            return await _dbSet.Where(predicado).ToListAsync(cancellationToken);
+        }
     }
-}

--- a/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/Ubicaciones/LugaresReferenciaRepository.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/Ubicaciones/LugaresReferenciaRepository.cs
@@ -1,4 +1,6 @@
 using Microsoft.EntityFrameworkCore;
+using System.Threading;
+using System.Threading.Tasks;
 using BackendCConecta.Dominio.Entidades.Ubicaciones;
 using BackendCConecta.Dominio.Repositorios;
 using BackendCConecta.Infraestructura.Persistencia;
@@ -12,35 +14,35 @@ public class LugaresReferenciaRepository : ILugaresReferenciaRepository
     public LugaresReferenciaRepository(AppDbContext context)
         => _context = context;
 
-    public async Task<LugaresReferencia?> ObtenerPorIdAsync(int id)
+    public async Task<LugaresReferencia?> ObtenerPorIdAsync(int id, CancellationToken cancellationToken = default)
     {
         return await _context.LugaresReferencias
             .AsNoTracking()
-            .FirstOrDefaultAsync(x => x.IdLugar == id);
+            .FirstOrDefaultAsync(x => x.IdLugar == id, cancellationToken);
     }
 
-    public async Task<IEnumerable<LugaresReferencia>> ListarAsync()
+    public async Task<IEnumerable<LugaresReferencia>> ListarAsync(CancellationToken cancellationToken = default)
     {
         return await _context.LugaresReferencias
             .AsNoTracking()
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
     }
 
-    public async Task InsertarAsync(LugaresReferencia entidad)
+    public async Task InsertarAsync(LugaresReferencia entidad, CancellationToken cancellationToken = default)
     {
-        await _context.LugaresReferencias.AddAsync(entidad);
-        await _context.SaveChangesAsync();
+        await _context.LugaresReferencias.AddAsync(entidad, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
     }
 
-    public async Task ActualizarAsync(LugaresReferencia entidad)
+    public async Task ActualizarAsync(LugaresReferencia entidad, CancellationToken cancellationToken = default)
     {
         _context.LugaresReferencias.Update(entidad);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(cancellationToken);
     }
 
-    public async Task EliminarAsync(LugaresReferencia entidad)
+    public async Task EliminarAsync(LugaresReferencia entidad, CancellationToken cancellationToken = default)
     {
         _context.LugaresReferencias.Remove(entidad);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(cancellationToken);
     }
 }

--- a/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/Ubicaciones/UbicacionSistemaRepository.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Repositorios/Ubicaciones/UbicacionSistemaRepository.cs
@@ -1,45 +1,50 @@
-﻿using Microsoft.EntityFrameworkCore;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using BackendCConecta.Dominio.Entidades.Ubicaciones;
 using BackendCConecta.Dominio.Repositorios;
 using BackendCConecta.Infraestructura.Persistencia;
 
-namespace BackendCConecta.Infraestructura.Repositorios.Ubicaciones
+namespace BackendCConecta.Infraestructura.Repositorios.Ubicaciones;
+
+public class UbicacionSistemaRepository : IUbicacionesSistemaRepository
 {
-    public class UbicacionSistemaRepository : IUbicacionesSistemaRepository
+    private readonly AppDbContext _context;
+
+    public UbicacionSistemaRepository(AppDbContext context)
     {
-        private readonly AppDbContext _context;
+        _context = context;
+    }
 
-        public UbicacionSistemaRepository(AppDbContext context)
-        {
-            _context = context;
-        }
+    public async Task<UbicacionSistema?> ObtenerPorIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        return await _context.UbicacionesSistema
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.IdUbicacion == id, cancellationToken);
+    }
 
-        public async Task<UbicacionSistema?> ObtenerPorIdAsync(int id)
-        {
-            return await _context.UbicacionesSistema.FindAsync(id);
-        }
+    public async Task<IEnumerable<UbicacionSistema>> ListarAsync(CancellationToken cancellationToken = default)
+    {
+        return await _context.UbicacionesSistema
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+    }
 
-        public async Task<IEnumerable<UbicacionSistema>> ListarAsync()
-        {
-            return await _context.UbicacionesSistema.ToListAsync();
-        }
+    public async Task InsertarAsync(UbicacionSistema entidad, CancellationToken cancellationToken = default)
+    {
+        await _context.UbicacionesSistema.AddAsync(entidad, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
 
-        public async Task InsertarAsync(UbicacionSistema entidad)
-        {
-            await _context.UbicacionesSistema.AddAsync(entidad);
-            await _context.SaveChangesAsync();
-        }
+    public async Task ActualizarAsync(UbicacionSistema entidad, CancellationToken cancellationToken = default)
+    {
+        _context.UbicacionesSistema.Update(entidad);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
 
-        public async Task ActualizarAsync(UbicacionSistema entidad)
-        {
-            _context.UbicacionesSistema.Update(entidad);
-            await _context.SaveChangesAsync();
-        }
-
-        public async Task EliminarAsync(UbicacionSistema entidad)
-        {
-            _context.UbicacionesSistema.Remove(entidad);
-            await _context.SaveChangesAsync();
-        }
+    public async Task EliminarAsync(UbicacionSistema entidad, CancellationToken cancellationToken = default)
+    {
+        _context.UbicacionesSistema.Remove(entidad);
+        await _context.SaveChangesAsync(cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
- allow passing `CancellationToken` through repository interfaces and implementations
- propagate tokens to EF Core operations in Ubicacion and generic repositories
- standardize Ubicaciones-related repositories with token-aware methods

## Testing
- `dotnet build BackendCConecta/BackendCConecta/BackendCConecta.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896b6f915ec832eb49751b570ed7f4e