### PR TITLE
Configure DI scanning with Scrutor

### DIFF
--- a/BackendCConecta/BackendCConecta/BackendCConecta.csproj
+++ b/BackendCConecta/BackendCConecta/BackendCConecta.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="MediatR" Version="12.2.0" />
+    <PackageReference Include="Scrutor" Version="4.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.19" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.19" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.17" />

--- a/BackendCConecta/BackendCConecta/Infraestructura/Servicios/Roles/RolCommandService.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Servicios/Roles/RolCommandService.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using BackendCConecta.Aplicacion.Modulos.Roles.Interfaces;
+
+namespace BackendCConecta.Infraestructura.Servicios.Roles;
+
+public class RolCommandService : IRolCommandService
+{
+    public Task<bool> AsignarRolAsync(int idDatosUsuario, int idRol)
+        => Task.FromResult(true);
+
+    public Task<bool> RemoverRolAsync(int idDatosUsuario, int idRol)
+        => Task.FromResult(true);
+}

--- a/BackendCConecta/BackendCConecta/Program.cs
+++ b/BackendCConecta/BackendCConecta/Program.cs
@@ -11,6 +11,8 @@ using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Annotations;
 using Swashbuckle.AspNetCore.Filters;
 using System.Reflection;
+using BackendCConecta.Aplicacion;
+using BackendCConecta.Infraestructura;
 using BackendCConecta.Api.Middlewares;
 using BackendCConecta.Aplicacion.Comportamientos;
 using BackendCConecta.Aplicacion.InterfacesGenerales;
@@ -88,26 +90,77 @@ builder.Services.AddAutoMapper(
 builder.Services.AddScoped<IJwtTokenGenerator, JwtTokenGenerator>();
 builder.Services.AddScoped<IPasswordHasher<Usuario>, PasswordHasher<Usuario>>();
 builder.Services.AddScoped<IAuthService, AuthService>();
-builder.Services.AddScoped<IEmailService, EmailService>();
-builder.Services.AddScoped<IFileStorageService, FileStorageService>();
-builder.Services.AddScoped<IUsuarioService, UsuarioService>();
-builder.Services.AddScoped<IUsuarioCommandService, UsuarioCommandService>();
-builder.Services.AddScoped<IUsuarioQueryService, UsuarioQueryService>();
-builder.Services.AddScoped<IUsuarioRepository, UsuarioRepository>();
-builder.Services.AddScoped(typeof(IRepositorioGenerico<>), typeof(RepositorioGenerico<>));
-builder.Services.AddScoped<IDatosUsuarioRepository, DatosUsuarioRepository>();
-builder.Services.AddScoped<IDatosUsuarioQueryService, DatosUsuarioQueryService>();
-builder.Services.AddScoped<IDatosPersonaRepository, DatosPersonaRepository>();
-builder.Services.AddScoped<IDatosPersonaQueryService, DatosPersonaQueryService>();
-builder.Services.AddScoped<IDatosEmpresaRepository, DatosEmpresaRepository>();
-builder.Services.AddScoped<IDatosEmpresaQueryService, DatosEmpresaQueryService>();
-builder.Services.AddScoped<IUbicacionesSistemaRepository, UbicacionSistemaRepository>();
 builder.Services.AddScoped<ICampaniaCommandService, CampaniaService>();
 builder.Services.AddScoped<ICampaniaQueryService, CampaniaService>();
 builder.Services.AddScoped<IFechasImportantesService, FechasImportantesService>();
 builder.Services.AddScoped<IStaffService, StaffService>();
-builder.Services.AddScoped<ITransactionService, TransactionService>();
 builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(TransactionBehavior<,>));
+
+builder.Services.Scan(scan => scan
+    .FromAssemblies(
+        typeof(BackendCConecta.Infraestructura.AssemblyMarker).Assembly,
+        typeof(BackendCConecta.Aplicacion.AssemblyMarker).Assembly)
+    // Servicios de dominio / aplicación implementados en Infraestructura.Servicios...
+    .AddClasses(c => c.InNamespaces(
+        "BackendCConecta.Infraestructura.Servicios",
+        "BackendCConecta.Infraestructura.Servicios.Usuarios",
+        "BackendCConecta.Infraestructura.Servicios.Contactos",
+        "BackendCConecta.Infraestructura.Servicios.Colaboradores",
+        "BackendCConecta.Infraestructura.Servicios.Acuerdos",
+        "BackendCConecta.Infraestructura.Servicios.Publicaciones",
+        "BackendCConecta.Infraestructura.Servicios.Paquetes",
+        "BackendCConecta.Infraestructura.Servicios.Multimedia",
+        "BackendCConecta.Infraestructura.Servicios.Intereses",
+        "BackendCConecta.Infraestructura.Servicios.Historiales",
+        "BackendCConecta.Infraestructura.Servicios.Empresas",
+        "BackendCConecta.Infraestructura.Servicios.Roles",
+        "BackendCConecta.Infraestructura.Servicios.Staff"))
+        .AsImplementedInterfaces()
+        .WithScopedLifetime()
+
+    // Repositorios implementados en Infraestructura.Repositorios...
+    .AddClasses(c => c.InNamespaces(
+        "BackendCConecta.Infraestructura.Repositorios",
+        "BackendCConecta.Infraestructura.Repositorios.DatosUsuarios",
+        "BackendCConecta.Infraestructura.Repositorios.DatosPersonas",
+        "BackendCConecta.Infraestructura.Repositorios.DatosEmpresas",
+        "BackendCConecta.Infraestructura.Repositorios.Usuarios",
+        "BackendCConecta.Infraestructura.Repositorios.Ubicaciones",
+        "BackendCConecta.Infraestructura.Repositorios.Publicaciones",
+        "BackendCConecta.Infraestructura.Repositorios.Paquetes",
+        "BackendCConecta.Infraestructura.Repositorios.Multimedia",
+        "BackendCConecta.Infraestructura.Repositorios.Intereses",
+        "BackendCConecta.Infraestructura.Repositorios.Historiales",
+        "BackendCConecta.Infraestructura.Repositorios.Empresas",
+        "BackendCConecta.Infraestructura.Repositorios.Roles",
+        "BackendCConecta.Infraestructura.Repositorios.Staff"))
+        .AsImplementedInterfaces()
+        .WithScopedLifetime()
+);
+
+// Registros explícitos de respaldo
+builder.Services.AddScoped<BackendCConecta.Aplicacion.Modulos.Contactos.Interfaces.IContactosService,
+                           BackendCConecta.Aplicacion.Modulos.Contactos.Servicios.ContactosService>();
+builder.Services.AddScoped<BackendCConecta.Aplicacion.Modulos.Colaboradores.Interfaces.IColaboradoresService,
+                           BackendCConecta.Aplicacion.Modulos.Colaboradores.Servicios.ColaboradoresService>();
+builder.Services.AddScoped<BackendCConecta.Aplicacion.Modulos.Acuerdos.Interfaces.IAcuerdoCommandService,
+                           BackendCConecta.Infraestructura.Servicios.Acuerdos.AcuerdoComercialCommandService>();
+builder.Services.AddScoped<BackendCConecta.Aplicacion.Modulos.Acuerdos.Interfaces.IAcuerdoQueryService,
+                           BackendCConecta.Infraestructura.Servicios.Acuerdos.AcuerdoComercialQueryService>();
+builder.Services.AddScoped<BackendCConecta.Aplicacion.Modulos.Publicaciones.Interfaces.IPublicacionesService,
+                           BackendCConecta.Aplicacion.Modulos.Publicaciones.Servicios.PublicacionesService>();
+builder.Services.AddScoped<BackendCConecta.Aplicacion.Modulos.Paquetes.Interfaces.IPaquetesService,
+                           BackendCConecta.Aplicacion.Modulos.Paquetes.Servicios.PaquetesService>();
+builder.Services.AddScoped<BackendCConecta.Aplicacion.Modulos.Multimedia.Interfaces.IMultimediaService,
+                           BackendCConecta.Aplicacion.Modulos.Multimedia.Servicios.MultimediaService>();
+builder.Services.AddScoped<BackendCConecta.Aplicacion.Modulos.Intereses.Interfaces.IInteresesService,
+                           BackendCConecta.Aplicacion.Modulos.Intereses.Servicios.InteresesService>();
+builder.Services.AddScoped<BackendCConecta.Aplicacion.Modulos.Historiales.Interfaces.IHistorialesService,
+                           BackendCConecta.Aplicacion.Modulos.Historiales.Servicios.HistorialesService>();
+builder.Services.AddScoped<BackendCConecta.Aplicacion.Modulos.Empresas.Interfaces.IEmpresasService,
+                           BackendCConecta.Aplicacion.Modulos.Empresas.Servicios.EmpresasService>();
+builder.Services.AddScoped<BackendCConecta.Aplicacion.Modulos.Roles.Interfaces.IRolCommandService,
+                           BackendCConecta.Infraestructura.Servicios.Roles.RolCommandService>();
 
 builder.Services
     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)


### PR DESCRIPTION
## Summary
- Add Scrutor package and configure assembly scanning for services and repositories
- Register application service fallbacks and add stub role command service

## Testing
- `dotnet clean` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*
- `dotnet run --project BackendCConecta/BackendCConecta/BackendCConecta.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689753cc2a2c832ea68870e59422e377