### PR TITLE
Kill locked exe and wire current user service

### DIFF
--- a/BackendCConecta/BackendCConecta/Aplicacion/InterfacesGenerales/ICurrentUserService.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/InterfacesGenerales/ICurrentUserService.cs
@@ -1,15 +1,11 @@
-namespace BackendCConecta.Aplicacion.InterfacesGenerales;
-
-/// <summary>
-/// Servicio para obtener información del usuario autenticado.
-/// </summary>
-public interface ICurrentUserService
+namespace BackendCConecta.Aplicacion.InterfacesGenerales
 {
-    /// <summary>
-    /// Determina si el usuario actual posee el rol especificado.
-    /// </summary>
-    /// <param name="role">Nombre del rol a verificar.</param>
-    /// <returns><c>true</c> si el usuario tiene el rol; de lo contrario, <c>false</c>.</returns>
-    bool HasRole(string role);
+    public interface ICurrentUserService
+    {
+        string? UserId { get; }
+        string? Email { get; }
+        bool IsAuthenticated { get; }
+        bool IsInRole(string role);
+        IEnumerable<System.Security.Claims.Claim> Claims { get; }
+    }
 }
-

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Handlers/AsignarRolHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Handlers/AsignarRolHandler.cs
@@ -14,17 +14,17 @@ namespace BackendCConecta.Aplicacion.Modulos.Roles.Handlers
     public class AsignarRolHandler : IRequestHandler<AsignarRolCommand, bool>
     {
         private readonly IRolCommandService _rolCommandService;
-        private readonly ICurrentUserService _currentUserService;
+        private readonly ICurrentUserService _currentUser;
 
-        public AsignarRolHandler(IRolCommandService rolCommandService, ICurrentUserService currentUserService)
+        public AsignarRolHandler(IRolCommandService rolCommandService, ICurrentUserService currentUser)
         {
             _rolCommandService = rolCommandService;
-            _currentUserService = currentUserService;
+            _currentUser = currentUser;
         }
 
         public async Task<bool> Handle(AsignarRolCommand request, CancellationToken cancellationToken)
         {
-            if (!_currentUserService.HasRole("administrador"))
+            if (!_currentUser.IsInRole("administrador"))
             {
                 throw new UnauthorizedAccessException("Usuario sin permisos para asignar roles.");
             }

--- a/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Handlers/RemoverRolHandler.cs
+++ b/BackendCConecta/BackendCConecta/Aplicacion/Modulos/Roles/Handlers/RemoverRolHandler.cs
@@ -14,17 +14,17 @@ namespace BackendCConecta.Aplicacion.Modulos.Roles.Handlers
     public class RemoverRolHandler : IRequestHandler<RemoverRolCommand, bool>
     {
         private readonly IRolCommandService _rolCommandService;
-        private readonly ICurrentUserService _currentUserService;
+        private readonly ICurrentUserService _currentUser;
 
-        public RemoverRolHandler(IRolCommandService rolCommandService, ICurrentUserService currentUserService)
+        public RemoverRolHandler(IRolCommandService rolCommandService, ICurrentUserService currentUser)
         {
             _rolCommandService = rolCommandService;
-            _currentUserService = currentUserService;
+            _currentUser = currentUser;
         }
 
         public async Task<bool> Handle(RemoverRolCommand request, CancellationToken cancellationToken)
         {
-            if (!_currentUserService.HasRole("administrador"))
+            if (!_currentUser.IsInRole("administrador"))
             {
                 throw new UnauthorizedAccessException("Usuario sin permisos para modificar roles.");
             }

--- a/BackendCConecta/BackendCConecta/BackendCConecta.csproj
+++ b/BackendCConecta/BackendCConecta/BackendCConecta.csproj
@@ -48,13 +48,8 @@
     <Exec Command="dotnet build-server shutdown" ContinueOnError="true" />
   </Target>
 
-  <!-- Matar instancia previa de la app (solo Windows) antes del Build -->
-  <Target Name="KillRunningBackendCConecta" BeforeTargets="Build" Condition="'$(OS)'=='Windows_NT'">
-    <!-- Intenta terminar el proceso por nombre; ignora error si no existe -->
-    <Exec Command="taskkill /F /IM BackendCConecta.exe /T" ContinueOnError="true" />
-    <!-- Como último recurso, intenta también matar dotnet.exe si mantiene el lock (comentado por defecto):
-    <Exec Command="taskkill /F /IM dotnet.exe /T" ContinueOnError="true" />
-    -->
+  <Target Name="KillLockedExeOnDebug" BeforeTargets="Build" Condition="'$(Configuration)' == 'Debug' AND '$(OS)' == 'Windows_NT'">
+    <Exec Command="taskkill /F /IM BackendCConecta.exe" IgnoreExitCode="true" />
   </Target>
 
 </Project>

--- a/BackendCConecta/BackendCConecta/Infraestructura/Seguridad/CurrentUserService.cs
+++ b/BackendCConecta/BackendCConecta/Infraestructura/Seguridad/CurrentUserService.cs
@@ -1,0 +1,26 @@
+using System.Security.Claims;
+using BackendCConecta.Aplicacion.InterfacesGenerales;
+using Microsoft.AspNetCore.Http;
+
+namespace BackendCConecta.Infraestructura.Seguridad
+{
+    public class CurrentUserService : ICurrentUserService
+    {
+        private readonly IHttpContextAccessor _http;
+
+        public CurrentUserService(IHttpContextAccessor http) => _http = http;
+
+        private ClaimsPrincipal? Principal => _http.HttpContext?.User;
+
+        public string? UserId => Principal?.FindFirstValue(ClaimTypes.NameIdentifier)
+                              ?? Principal?.FindFirstValue("sub");
+
+        public string? Email => Principal?.FindFirstValue(ClaimTypes.Email);
+
+        public bool IsAuthenticated => Principal?.Identity?.IsAuthenticated == true;
+
+        public bool IsInRole(string role) => Principal?.IsInRole(role) == true;
+
+        public IEnumerable<Claim> Claims => Principal?.Claims ?? Enumerable.Empty<Claim>();
+    }
+}

--- a/BackendCConecta/BackendCConecta/Program.cs
+++ b/BackendCConecta/BackendCConecta/Program.cs
@@ -69,8 +69,8 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 builder.Services.AddMediatR(cfg =>
 {
     cfg.RegisterServicesFromAssemblies(
-        typeof(BackendCConecta.Aplicacion.AssemblyMarker).Assembly,
-        typeof(Program).Assembly
+        Assembly.GetExecutingAssembly(),
+        typeof(BackendCConecta.Aplicacion.AssemblyMarker).Assembly
     );
 });
 
@@ -86,6 +86,9 @@ builder.Services.AddValidatorsFromAssemblies(new[]
 builder.Services.AddAutoMapper(
     typeof(BackendCConecta.Aplicacion.AssemblyMarker).Assembly
 );
+
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();
 
 builder.Services.AddScoped<IJwtTokenGenerator, JwtTokenGenerator>();
 builder.Services.AddScoped<IPasswordHasher<Usuario>, PasswordHasher<Usuario>>();


### PR DESCRIPTION
## Summary
- stop stray BackendCConecta.exe processes before debug builds
- add `ICurrentUserService` abstraction and `CurrentUserService` implementation
- register MediatR and current user service in DI and use in role handlers

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build -c Debug` *(fails: command not found)*
- `dotnet run -c Debug` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*
- `curl -L https://dot.net/v1/dotnet-install.sh` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_6897648a80a4832e979cf3b7ae32394d