### PR TITLE
Handle locked files on clean

### DIFF
--- a/BackendCConecta/BackendCConecta/BackendCConecta.csproj
+++ b/BackendCConecta/BackendCConecta/BackendCConecta.csproj
@@ -14,19 +14,19 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <!-- Opcional: evita generar EXE en Debug; correrá como DLL (dotnet BackendCConecta.dll) -->
+    <!-- Opcional: en Debug no generar EXE; corre con DLL para reducir bloqueos -->
     <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
-  <Target Name="KillLockedBackend" BeforeTargets="Build">
-    <!-- Intenta cerrar cualquier instancia previa que bloquee la compilación -->
+  <Target Name="KillIfLocked" BeforeTargets="Clean;Build">
+    <!-- Cierra cualquier instancia del ejecutable de la app -->
     <Exec Command="taskkill /F /IM BackendCConecta.exe" IgnoreExitCode="true" />
-    <!-- Si estaba corriendo con dotnet, también intenta cerrar el dotnet host antiguas -->
+    <!-- Cierra host de .NET si dejó handles abiertos (watch/run) -->
     <Exec Command="taskkill /F /IM dotnet.exe" IgnoreExitCode="true" />
   </Target>
 
-  <Target Name="PreCleanIfNeeded" BeforeTargets="CoreCompile">
-    <!-- Elimina restos de compilaciones anteriores si siguen bloqueados -->
+  <Target Name="SafePreClean" BeforeTargets="CoreClean">
+    <!-- Limpieza forzada de artefactos si quedaron residuos bloqueados -->
     <RemoveDir Directories='$(MSBuildProjectDirectory)\bin\Debug\net8.0' />
     <RemoveDir Directories='$(MSBuildProjectDirectory)\obj\Debug\net8.0' />
   </Target>

--- a/BackendCConecta/BackendCConecta/tools/unlock-and-clean.ps1
+++ b/BackendCConecta/BackendCConecta/tools/unlock-and-clean.ps1
@@ -6,9 +6,9 @@ taskkill /F /IM BackendCConecta.exe
 taskkill /F /IM dotnet.exe
 
 # Limpieza de bin/obj (Debug por defecto)
-$projRoot = Split-Path -Parent $MyInvocation.MyCommand.Path | Split-Path -Parent
-$bin = Join-Path $projRoot "bin\Debug\net8.0"
-$obj = Join-Path $projRoot "obj\Debug\net8.0"
+$root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$bin = Join-Path $root "bin\Debug\net8.0"
+$obj = Join-Path $root "obj\Debug\net8.0"
 
 if (Test-Path $bin) { Remove-Item $bin -Recurse -Force }
 if (Test-Path $obj) { Remove-Item $obj -Recurse -Force }


### PR DESCRIPTION
## Summary
- ensure debug builds use DLL to avoid locked EXE
- kill lingering BackendCConecta.exe/dotnet.exe before clean/build
- force-clean bin/obj via SafePreClean
- provide unlock-and-clean helper script

## Testing
- `pwsh -v` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68977c92087c832ebc789b3f9206d3ca